### PR TITLE
Watchkeeper Gargolmar

### DIFF
--- a/Updates/842_AnonXS_WatchkeeperGargolmar.sql
+++ b/Updates/842_AnonXS_WatchkeeperGargolmar.sql
@@ -1,0 +1,3 @@
+UPDATE `spell_template` SET `StackAmount` = 10 WHERE `id` IN (30641, 36814);
+
+UPDATE `creature_linking` SET `flag` = `flag`|4 WHERE `master_guid` = 62083;


### PR DESCRIPTION
Open Issues from https://jira.vengeancewow.com/browse/TBC-2084

Mortal Wound should stack up to 10 not 8
http://wowwiki.wikia.com/wiki/Watchkeeper_Gargolmar?oldid=1479057

Adds should respawn on evade

---

https://github.com/cmangos/mangos-tbc/blob/master/src/scriptdev2/scripts/outland/hellfire_citadel/hellfire_ramparts/boss_watchkeeper_gargolmar.cpp#L38