### PR TITLE
Quest 9385 - Quillfang Skitterers shouldn't give quest credit

### DIFF
--- a/Updates/SpinOnTop/xxx_quest_rampaging_ravagers_id(9385).sql
+++ b/Updates/SpinOnTop/xxx_quest_rampaging_ravagers_id(9385).sql
@@ -1,0 +1,7 @@
+-- Quillfang Skitterers should not count towards the quest Rampaging Ravagers until wotlk
+-- http://www.wowhead.com/quest=9385/rampaging-ravagers#comments:id=26041
+-- http://www.wowhead.com/npc=19189/quillfang-skitterer
+
+UPDATE `creature_template` SET `KillCredit1`=0 WHERE `entry`=19189;
+
+


### PR DESCRIPTION
Bug report from Jira: https://jira.vengeancewow.com/browse/TBC-1664

Source: http://www.wowhead.com/quest=9385/rampaging-ravagers#comments:id=26041

Quillfang Skitterers should not give quest credit in tbc.

> By Avendhras (1,503 – 4·16) on 2007/01/28 (Patch 2.0.6)		
> Note that there are two types of ravager near Falcon's Watch -- the quillfang ravager and the quillfang skitterer. You do not receive credit for killing the skitterers, which is unfortunate because they outnumber the ravagers by a pretty healthy margin, and they are very fast, and very aggressive. Also, they're colored differently than the ravagers -- they're mostly blue while the ravagers are a uniform drab green.
> 
> That being the case, when you do this quest, chances are you'll have a lot of company, and all you can really do is wait for the ravagers to respawn.
> 5
> ZippyKeno on 2009/01/24 (Patch 3.0.8)
> The skitterer DO count for a kill
> 3
> chilly028 on 2009/02/03 (Patch 3.0.8)
> As of February 2, 2009. The Quillfang Skitterers do count towards this quest.

> By devarim (165 – 1) on 2007/12/01 (Patch 2.3.0)		
> While the Skitterers are pretty much useless...they do have a small purpose...I had the quest Ravager Egg roundup from Legassi at the crashed zeppelin, and I got 3 or 4 of the eggs from the skitterers. 