### PR TITLE
Create Zandalar Demoniac's Robe - Required Level Fix

### DIFF
--- a/Updates/Zandalar Demoniac's Robe - Required Level Fix
+++ b/Updates/Zandalar Demoniac's Robe - Required Level Fix
@@ -1,0 +1,1 @@
+REPLACE INTO `item_template` (`entry`, `RequiredLevel`) VALUES (20033, 60);


### PR DESCRIPTION
Zandalar Demoniac's Robe Required Level should be 60 not 0