### PR TITLE
Create Fix - Zandalar Confessor's Mantle

### DIFF
--- a/Updates/Fix - Zandalar Confessor's Mantle
+++ b/Updates/Fix - Zandalar Confessor's Mantle
@@ -1,0 +1,1 @@
+REPLACE INTO `item_template` (`entry`, `RequiredLevel`) VALUES (19841, 60);


### PR DESCRIPTION
Zandalar Confessor's Mantle. Required Level should be 60 not 0