### PR TITLE
Battered crate trap GO 181584

### DIFF
--- a/Updates/792_Battered_Crate_Trap_fixed.sql
+++ b/Updates/792_Battered_Crate_Trap_fixed.sql
@@ -1,0 +1,2 @@
+-- Battered Crate Trap not disappearing
+UPDATE `mangos`.`gameobject_template` SET `data4`='1', `data5`='0' WHERE `entry`='181584';


### PR DESCRIPTION
Changed the cooldown to 0 and charges to 1 so it dissapears when the linked chest has dissapeared.

as seen here: https://www.youtube.com/watch?v=gdMZ41hRe84&feature=youtu.be&t=60
Current state: light above the chest would stay up infinitely
Changed state: light starts to dissapear as soon as the chest has dissapeared (give or take a second)