### PR TITLE
[ACID] Netherstrand Longbow 21268

### DIFF
--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -31547,7 +31547,7 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 -- Thaladred the Darkener (20064) - boss_thaladred_the_darkener
 -- Netherstrand Longbow
 ('2126801','21268','4','0','100','2','0','0','0','0','49','1','0','0','20','0','0','0','0','0','0','0','Netherstrand Longbow - Enable Dynamic Movement and Prevent Melee on Aggro'),
-('2126802','21268','9','0','100','3','0','100','3000','6000','11','36980','1','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Shoot and Set Ranged Weapon Model'),
+('2126802','21268','9','0','100','3','0','100','3000','3000','11','36980','1','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Shoot and Set Ranged Weapon Model'),
 ('2126803','21268','0','0','100','3','7000','11000','12000','16000','11','36979','1','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Multi-Shot and Set Ranged Weapon Model'),
 ('2126804','21268','9','0','100','3','0','20','24000','30000','11','36994','0','1','0','0','0','0','0','0','0','0','Netherstrand Longbow - Cast Blink'),
 ('2126805','21268','9','0','100','3','9','80','1000','1000','49','1','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Enable Dynamic Movement at 9-80 Yards'),

--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -31547,12 +31547,13 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 -- Thaladred the Darkener (20064) - boss_thaladred_the_darkener
 -- Netherstrand Longbow
 ('2126801','21268','4','0','100','2','0','0','0','0','49','1','0','0','20','0','0','0','0','0','0','0','Netherstrand Longbow - Enable Dynamic Movement and Prevent Melee on Aggro'),
-('2126802','21268','9','0','100','3','0','100','4000','6000','11','36980','4','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Shoot and Set Ranged Weapon Model'),
-('2126803','21268','0','0','100','3','7000','11000','12000','16000','11','36979','4','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Multi-Shot and Set Ranged Weapon Model'),
+('2126802','21268','9','0','100','3','0','100','3000','6000','11','36980','1','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Shoot and Set Ranged Weapon Model'),
+('2126803','21268','0','0','100','3','7000','11000','12000','16000','11','36979','1','0','40','2','0','0','0','0','0','0','Netherstrand Longbow - Cast Multi-Shot and Set Ranged Weapon Model'),
 ('2126804','21268','9','0','100','3','0','20','24000','30000','11','36994','0','1','0','0','0','0','0','0','0','0','Netherstrand Longbow - Cast Blink'),
 ('2126805','21268','9','0','100','3','9','80','1000','1000','49','1','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Enable Dynamic Movement at 9-80 Yards'),
 ('2126806','21268','9','0','100','3','0','8','1000','1000','49','0','0','0','20','1','0','0','40','1','0','0','Netherstrand Longbow - Disable Dynamic Movement and Enable Melee and Set Melee Weapon Model at 0-8 Yards'),
 ('2126807','21268','7','0','100','2','0','0','0','0','40','1','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Set Melee Weapon Model on Evade'),
+('2126808','21268','32','0','100','3','0','5','5000','5000','14','-100','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Drop Aggro in Range'),
 -- Devastation
 ('2126901','21269','9','0','100','3','0','8','11000','15000','11','36981','0','0','0','0','0','0','0','0','0','0','Devastation - Cast Whirlwind'),
 -- Cosmic Infuser

--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -31554,7 +31554,6 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('2126806','21268','9','0','100','3','0','8','1000','1000','49','0','0','0','20','1','0','0','40','1','0','0','Netherstrand Longbow - Disable Dynamic Movement and Enable Melee and Set Melee Weapon Model at 0-8 Yards'),
 ('2126807','21268','7','0','100','2','0','0','0','0','40','1','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Set Melee Weapon Model on Evade'),
 ('2126808','21268','32','0','100','3','0','5','5000','5000','14','-100','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Drop Aggro in Range'),
-('2126809','21268','21','0','100','2','0','0','0','0','41','10000','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Despawn on Reached Home'),
 -- Devastation
 ('2126901','21269','9','0','100','3','0','8','11000','15000','11','36981','0','0','0','0','0','0','0','0','0','0','Devastation - Cast Whirlwind'),
 -- Cosmic Infuser

--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -31554,6 +31554,7 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('2126806','21268','9','0','100','3','0','8','1000','1000','49','0','0','0','20','1','0','0','40','1','0','0','Netherstrand Longbow - Disable Dynamic Movement and Enable Melee and Set Melee Weapon Model at 0-8 Yards'),
 ('2126807','21268','7','0','100','2','0','0','0','0','40','1','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Set Melee Weapon Model on Evade'),
 ('2126808','21268','32','0','100','3','0','5','5000','5000','14','-100','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Drop Aggro in Range'),
+('2126809','21268','21','0','100','2','0','0','0','0','41','10000','0','0','0','0','0','0','0','0','0','0','Netherstrand Longbow - Despawn on Reached Home'),
 -- Devastation
 ('2126901','21269','9','0','100','3','0','8','11000','15000','11','36981','0','0','0','0','0','0','0','0','0','0','Devastation - Cast Whirlwind'),
 -- Cosmic Infuser


### PR DESCRIPTION
http://wowwiki.wikia.com/wiki/Kael%27thas_Sunstrider_(tactics)?oldid=1622799

Has a Multi-Shot attack, drops aggro if any melee or pet attack it. Preferably tanked by a hunter facing it away from the raid to avoid Multi-Shot hitting others. This is the most dangerous weapon and should be killed first by all hunters and ranged DPS which do not take part in the AoE.

* Shoot should prob have Maxrepeat lower as its just cancelled/delayed by multishot, sniffvalues with 15 repetitions had a average repetition of 4secs with mostly 3sec and sometimes 8 when there was a multishot in between.