### PR TITLE
[ACID] Eye of Culuthas 20394

### DIFF
--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -20793,6 +20793,7 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 -- Lee Sparks 20389
 -- Foreman Sundown 20393
 -- Eye of Culuthas 20394
+('2039401','20394','0','0','100','1','0','5000','12500','15000','11','36414','1','0','0','0','0','0','0','0','0','0','Eye of Culuthas - Cast Focused Bursts'),
 -- Overseer Seylanna 20397
 -- Terror Imp 20399
 -- Legion Shocktrooper


### PR DESCRIPTION
http://www.wowhead.com/npc=20394/eye-of-culuthas
https://web.archive.org/web/20111114133627/http://www.wowhead.com:80/npc=20394

Spawns are missing (OOC) Waypoint Script / Aura with http://www.wowhead.com/spell=36296/scan / http://www.wowhead.com/npc=21157/culuthas-scan-target-dummy involved.

Tongue Lash 36398 is not used by this npc, or not anymore