### PR TITLE
Overlord Mok'Morokk Not Hostile After Accepting Quest

### DIFF
--- a/Updates/1000_quest_overlord_morokk.sql
+++ b/Updates/1000_quest_overlord_morokk.sql
@@ -1,0 +1,1 @@
+UPDATE creature_template SET UnitFlags=64 WHERE entry = 4500;


### PR DESCRIPTION
https://tbc-twinhead.twinstar.cz/?quest=1173

The NPC does not turn aggressive after player accepts quest. The NPC flags are wrong on this NPC.