### PR TITLE
Fixes spawn locations for both undead and night elf

### DIFF
--- a/Updates/9xx_playercreateinfo_spawns.sql
+++ b/Updates/9xx_playercreateinfo_spawns.sql
@@ -1,0 +1,4 @@
+-- Fix spawn location for undead
+UPDATE `playercreateinfo` SET `position_x` = '1676.349976', `position_y` = '1677.449951', `position_z` = '121.669998', `orientation` = '2.705260' WHERE `race` = '5';
+-- Fix spawn location for night elf
+UPDATE `playercreateinfo` SET `position_x` = '10311.299805', `position_y` = '831.463013', `position_z` = '1326.410034', `orientation` = '5.480334' WHERE `race` = '4';


### PR DESCRIPTION
Currently players spawn on wrong position on both undead and night elf. The issue is mostly due to missing decimals. This fixes both spawns.
Credits go out to WoWCore for the coordinates.
https://github.com/RomanRom2/WoWCore/blob/master/05875_1.12.1/pas/sandbox/CharsConsts.pas#L143
https://github.com/RomanRom2/WoWCore/blob/master/05875_1.12.1/pas/sandbox/CharsConsts.pas#L75

Night elf mangos: .go xyz 10311.3 832.463 1326.41 1 5.69632
Night elf retail: .go xyz 10311.299805 831.463013 1326.410034 1 5.480334
Here is a comparison on night elves:
Mangos:
![mangos](https://user-images.githubusercontent.com/6137576/37768526-44026b5e-2dce-11e8-9f38-be3c8bb481c9.jpg)
TBC retail:
![tbc 4 april 2007](https://user-images.githubusercontent.com/6137576/37768524-43bf7baa-2dce-11e8-91ba-5e4558f19640.png)
![tbc ne](https://user-images.githubusercontent.com/6137576/37768525-43e016f8-2dce-11e8-9546-a5e46f058769.png)
WOTLK retail:
![wotlk ne](https://user-images.githubusercontent.com/6137576/37768654-b2aa49b4-2dce-11e8-8929-a1dc4778c9a3.png)
![wotlk nightelf](https://user-images.githubusercontent.com/6137576/37768656-b2cec91a-2dce-11e8-9116-9443a66a9fe5.png)

Undead mangos: .go xyz 1676.71 1678.31 121.67 0 2.70526
Undead retail: .go xyz 1676.349976 1677.449951 121.669998 0 2.705260
Undead comparison:
Mangos:
![mangos_ud](https://user-images.githubusercontent.com/6137576/37768716-e580dbc8-2dce-11e8-9889-21d257cf4bae.png)
WoW beta:
![wow beta](https://user-images.githubusercontent.com/6137576/37768746-fb6d4426-2dce-11e8-9198-466bb55cc9d4.jpg)
WOTLK retail:
![wotlk](https://user-images.githubusercontent.com/6137576/37768757-05822990-2dcf-11e8-9207-4cb4e959624d.png)




