### PR TITLE
Alterac Valley starting gate is now correctly non-interactable.

### DIFF
--- a/Updates/0758_alterac_valley_gate.sql
+++ b/Updates/0758_alterac_valley_gate.sql
@@ -1,0 +1,2 @@
+-- Alterac Valley: Starting gate is now correctly non-interactable: 
+update gameobject_template set faction = 114, flags = 32 where entry = 180424;


### PR DESCRIPTION
https://github.com/cmangos/issues/issues/1883

Alterac Valley starting gate is now correctly non-interactable by players, both Horde and Alliance.