### PR TITLE
Questline fix for exodar call of water

### DIFF
--- a/Updates/0774_call of_water_questline_fixes.sql
+++ b/Updates/0774_call of_water_questline_fixes.sql
@@ -1,0 +1,6 @@
+-- Questline Fixes for Call Of Water Exodar, Values pulled from http://web.archive.org/web/20070516023114/http://thottbot.com/q9502
+UPDATE `quest_template` SET `QuestLevel` = 20 WHERE `entry` = 9500;
+UPDATE `quest_template` SET `RewMoneyMaxLevel` = 930, `QuestLevel` = 20 WHERE `entry` IN (9501,9503);
+UPDATE `quest_template` SET `RewMoneyMaxLevel` = 1170, `QuestLevel` = 24 WHERE `entry` = 9504;
+UPDATE `quest_template` SET `RewMoneyMaxLevel` = 1110, `QuestLevel` = 23 WHERE `entry` = 9508;
+UPDATE `quest_template` SET `RewMoneyMaxLevel` = 1410, `QuestLevel` = 20 WHERE `entry` = 9509;


### PR DESCRIPTION
Questline was missing exp values. Pulled values from http://web.archive.org/web/20070514144939/http://www.thottbot.com/q9500

Let me know if the format needs to be different, I was only able to get XP actually rewarded when setting the QuestLevel variable correctly, -1 would never reward the experience.

Closed previous PR due to my screwup on rebase.