### PR TITLE
Can Not Interrupt Hurricane From Druid And NPC

### DIFF
--- a/Updates/0845_hurricane_interrupt_fix.sql
+++ b/Updates/0845_hurricane_interrupt_fix.sql
@@ -1,0 +1,2 @@
+UPDATE `spell_template` SET `InterruptFlags`=15 WHERE 
+`id`=16914 OR `id`=17401 OR `id`=17402 OR `id`=27012 OR `id`=27530 OR `id`=32717 OR `id`=40090;


### PR DESCRIPTION
Those two spells were totally missing InterruptFlags,
NPC could continue to cast even mooving, added standard
15 flag
Issue:
   https://github.com/cmangos/issues/issues/1865