### PR TITLE
1101_skyshatter_raiment_spellaffect.sql

### DIFF
--- a/Updates/0064_skyshatter_raiment_spellaffect.sql
+++ b/Updates/0064_skyshatter_raiment_spellaffect.sql
@@ -1,0 +1,4 @@
+-- Correct spell_affect mask for Improved Chain Heal 38435
+-- https://www.wowhead.com/item-set=683/skyshatter-raiment
+UPDATE spell_affect SET SpellFamilyMask = 256 WHERE entry = 38435;
+

--- a/Updates/1101_skyshatter_raiment_spellaffect.sql
+++ b/Updates/1101_skyshatter_raiment_spellaffect.sql
@@ -1,0 +1,1 @@
+UPDATE spell_affect SET SpellFamilyMask = 256 WHERE entry IN(38435);

--- a/Updates/1101_skyshatter_raiment_spellaffect.sql
+++ b/Updates/1101_skyshatter_raiment_spellaffect.sql
@@ -1,1 +1,0 @@
-UPDATE spell_affect SET SpellFamilyMask = 256 WHERE entry IN(38435);


### PR DESCRIPTION
-Adds correct SpellFamilyMask in spell_affect for 38435. Chainheal familymask is 256. Fixes set bonus for Skyshatter Raiment itemset.

" 38435 - Increases the amount healed by your Chain Heal ability by 5%.

