### PR TITLE
Fix for fel cannons moving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 /.buildpath
 /.externalToolBuilders
 
+# Visual studio directory
+/.vs
+
 # Numerous always-ignore extensions
 *.diff
 *.err

--- a/Updates/0249_fel_cannons.sql
+++ b/Updates/0249_fel_cannons.sql
@@ -1,0 +1,5 @@
+-- Update the fel cannon models to make sure they stay stationary
+UPDATE tbcmangos.creature_model_info SET Speedwalk = 0, SpeedRun = 0  where modelid = 18505 OR modelid = 17035 OR modelid = 11686 OR modelid = 1126 OR modelid = 16480 OR modelid = 19595 OR modelid = 21397 OR modelid = 5187;
+
+-- Update the fel cannons aswell to make sure the template does not overwrites the model info
+UPDATE tbcmangos.creature_template SET SpeedWalk = 0, SpeedRun = 0 where entry = 22461 OR entry = 19067 OR entry = 19210 OR entry = 19211 OR entry = 19212 OR entry = 19399 OR entry = 21233 OR entry = 22443 OR entry = 22451 OR entry = 22461 OR entry = 22495 OR entry = 23077 OR entry = 23278 OR entry = 23279 OR entry = 23485;

--- a/Updates/0249_fel_cannons.sql
+++ b/Updates/0249_fel_cannons.sql
@@ -1,5 +1,5 @@
 -- Update the fel cannon models to make sure they stay stationary
-UPDATE tbcmangos.creature_model_info SET Speedwalk = 0, SpeedRun = 0  where modelid = 18505 OR modelid = 17035 OR modelid = 11686 OR modelid = 1126 OR modelid = 16480 OR modelid = 19595 OR modelid = 21397 OR modelid = 5187;
+UPDATE creature_model_info SET Speedwalk = 0, SpeedRun = 0  where modelid = 18505 OR modelid = 17035 OR modelid = 11686 OR modelid = 1126 OR modelid = 16480 OR modelid = 19595 OR modelid = 21397 OR modelid = 5187;
 
 -- Update the fel cannons aswell to make sure the template does not overwrites the model info
-UPDATE tbcmangos.creature_template SET SpeedWalk = 0, SpeedRun = 0 where entry = 22461 OR entry = 19067 OR entry = 19210 OR entry = 19211 OR entry = 19212 OR entry = 19399 OR entry = 21233 OR entry = 22443 OR entry = 22451 OR entry = 22461 OR entry = 22495 OR entry = 23077 OR entry = 23278 OR entry = 23279 OR entry = 23485;
+UPDATE creature_template SET SpeedWalk = 0, SpeedRun = 0 where entry = 22461 OR entry = 19067 OR entry = 19210 OR entry = 19211 OR entry = 19212 OR entry = 19399 OR entry = 21233 OR entry = 22443 OR entry = 22451 OR entry = 22461 OR entry = 22495 OR entry = 23077 OR entry = 23278 OR entry = 23279 OR entry = 23485;


### PR DESCRIPTION
This PR will fix the fel cannons moving and following you around (wich they should not do).

all speed is set to 0 so they are stationary