### PR TITLE
Prevent Sneed from being un-summoned on Sneed Shredder death

### DIFF
--- a/Updates/0381_sneed_shredder.sql
+++ b/Updates/0381_sneed_shredder.sql
@@ -1,0 +1,2 @@
+-- Prevent Sneed from being despawned instantly after being summoned due to missing ACTION_T_SET_DESPAWN_AGGREGATION parameter
+UPDATE creature_ai_scripts SET action2_type = 62, action2_param1 = 0 WHERE id = 64203;


### PR DESCRIPTION
Due to commit [#d72eaf70388fce15efae580c5a392c7b8c29f563](https://github.com/cmangos/mangos-tbc/commit/d72eaf70388fce15efae580c5a392c7b8c29f563) summoned creatures are dispawned on caster death.

Therefore, Sneed Shredder encounter within the Deadmines is broken as Sneed will be un-summoned as soon as he's spawned.