### PR TITLE
Fix too big Trash in Naxx

### DIFF
--- a/Updates/0413_naxxramas_model_sizes.sql
+++ b/Updates/0413_naxxramas_model_sizes.sql
@@ -30,3 +30,5 @@ UPDATE creature_template SET Scale=1 WHERE entry=15976;
 UPDATE creature_template SET Scale=1 WHERE entry=16453;
 -- Carrion Spinner
 UPDATE creature_template SET Scale=1 WHERE entry=15975;
+-- Infectious Skitterer (this one was actually too small)
+UPDATE creature_template SET Scale=1 WHERE entry=15977;

--- a/Updates/0413_naxxramas_model_sizes.sql
+++ b/Updates/0413_naxxramas_model_sizes.sql
@@ -1,0 +1,32 @@
+-- Deathknight Captain
+UPDATE creature_template SET Scale=1 WHERE entry=16145;
+-- Deathknight
+UPDATE creature_template SET Scale=1 WHERE entry=16146;
+-- Necro Knight
+UPDATE creature_template SET Scale=1 WHERE entry=16165;
+-- Shade of Naxxramas
+UPDATE creature_template SET Scale=1 WHERE entry=16164;
+-- Deathknight Cavalier
+UPDATE creature_template SET Scale=1 WHERE entry=16163;
+-- Death Lord
+UPDATE creature_template SET Scale=1 WHERE entry=16861;
+-- Spirit of Naxxramas
+UPDATE creature_template SET Scale=1 WHERE entry=16449;
+-- Necropolis Acolyte
+UPDATE creature_template SET Scale=1 WHERE entry=16368;
+-- Plagued Gargoyle
+UPDATE creature_template SET Scale=1 WHERE entry=16446;
+-- Deathknight Vindicator
+UPDATE creature_template SET Scale=1 WHERE entry=16451;
+-- Patchwork Golem
+UPDATE creature_template SET Scale=1 WHERE entry=16017;
+-- Sludge Belcher
+UPDATE creature_template SET Scale=1 WHERE entry=16029;
+-- Necro Knight Guardian
+UPDATE creature_template SET Scale=1 WHERE entry=16452;
+-- Venom Stalker
+UPDATE creature_template SET Scale=1 WHERE entry=15976;
+-- Necro Stalker
+UPDATE creature_template SET Scale=1 WHERE entry=16453;
+-- Carrion Spinner
+UPDATE creature_template SET Scale=1 WHERE entry=15975;


### PR DESCRIPTION
Many trash mobs had an incorrect Scale value (0) which caused them to be enormous. Setting Scale to 1 fixes this issue.

Fixes https://github.com/cmangos/issues/issues/2386