### PR TITLE
Fix Faerlina's missing door

### DIFF
--- a/Updates/0425_naxxramas_faerlina_door_fix.sql
+++ b/Updates/0425_naxxramas_faerlina_door_fix.sql
@@ -1,0 +1,2 @@
+-- Adds missing door from Faerlina to Naxxramas outer ring
+INSERT INTO gameobject VALUES ( 9000116, 181167, 533, 1,3121.51, -3790.91, 273.936, 6.27873, 0, 0, 0.00222603, -0.999997, 25, 25, 100, 1);

--- a/Updates/0425_naxxramas_faerlina_door_fix.sql
+++ b/Updates/0425_naxxramas_faerlina_door_fix.sql
@@ -1,2 +1,3 @@
 -- Adds missing door from Faerlina to Naxxramas outer ring
+DELETE FROM gameobject WHERE guid = '9000116';
 INSERT INTO gameobject VALUES ( 9000116, 181167, 533, 1,3121.51, -3790.91, 273.936, 6.27873, 0, 0, 0.00222603, -0.999997, 25, 25, 100, 1);


### PR DESCRIPTION
In conjunction with https://github.com/cmangos/mangos-tbc/pull/432

No door existed previously.
The GUID was chosen by the game server and is thus a "generated" guid, I don't know how to pick a proper GUID, please advise or change.