### PR TITLE
Fix warning message that command doesn't exist

### DIFF
--- a/Updates/426_fix_combatstop_error.sql
+++ b/Updates/426_fix_combatstop_error.sql
@@ -1,0 +1,1 @@
+UPDATE command SET name="combat stop", help='Syntax: .combat stop [$playername]\r\nStop combat for selected character. If selected non-player then command applied to self. If $playername provided then attempt applied to online player $playername.' WHERE name="combatstop";


### PR DESCRIPTION
At some point the syntax was changed from `.combatstop` to `.combat stop`, but this field in the Database wasn't updated to reflect this change and now it is throwing warnings when the server is started.