### PR TITLE
Fix Thunderclap speed reduction

### DIFF
--- a/Updates/0440_thunderclap_fix.sql
+++ b/Updates/0440_thunderclap_fix.sql
@@ -1,0 +1,2 @@
+-- Fixes Thunderclap spell used by Sethekk Guards to use correct movement speed reduction
+UPDATE spell_template SET EffectRealPointsPerLevel2=0 WHERE id=33967;


### PR DESCRIPTION
Thunderclap used by Sethekk Guardians (in Sethekk Hall) used to reduce movement speed by ~99% in Heroic and ~80% in non-heroic, where it should instead be 40%

Fixes https://github.com/cmangos/issues/issues/2419