### PR TITLE
Hide Event Triggers for Non-GMs

### DIFF
--- a/Updates/0474_hide_event_triggers.sql
+++ b/Updates/0474_hide_event_triggers.sql
@@ -1,0 +1,20 @@
+-- Hide some event triggers for non-GMs
+-- https://github.com/cmangos/issues/issues/2469
+-- thx @killerwife
+
+-- Removing player visibility for the following objects:
+--   128972 Zul'Farrak Graves
+--   176750 Desolace Kodo Graveyard Skulls
+--   171941 Blackrock Keg Trap
+--   180391 Heart of Hakkar Spell Emitter
+--   176592 Shellfish Trap
+--   177493 Fire of Elune
+--   177529 Altar of Elune
+--   178124 Resonite Crystal
+--   178248 Naga Brazier
+--   181214 Necropolis critter spawner
+--   184718 Cauldron Summoner
+--   184722 Cauldron Bug Summoner
+--   103575 Containment Coffer TRAP
+
+UPDATE gameobject_template SET data8=1 WHERE entry IN(128972, 176750, 171941, 180391, 176592, 177493, 177529, 178124, 178248, 181214, 184718, 184722, 103575);


### PR DESCRIPTION
Fixes: https://github.com/cmangos/issues/issues/2469
Thanks @killerwife 

Removing player visibility for the following objects:
- 128972 Zul'Farrak Graves
- 176750 Desolace Kodo Graveyard Skulls
- 171941 Blackrock Keg Trap
- 180391 Heart of Hakkar Spell Emitter
- 176592 Shellfish Trap
- 177493 Fire of Elune
- 177529 Altar of Elune
- 178124 Resonite Crystal
- 178248 Naga Brazier
- 181214 Necropolis critter spawner
- 184718 Cauldron Summoner
- 184722 Cauldron Bug Summoner
- 103575 Containment Coffer TRAP

Identified via:
`SELECT * FROM gameobject_template WHERE type = 6 AND displayId = 327 AND data8 != 1`