### PR TITLE
Hide GO Traps for non-GMs

### DIFF
--- a/Updates/0481_hide_gotraps.sql
+++ b/Updates/0481_hide_gotraps.sql
@@ -1,0 +1,18 @@
+-- Hide Gameobject Traps to player characters.
+-- Removing player visibility for the following objects:
+--   128972 Zul'Farrak Graves
+--   176750 Desolace Kodo Graveyard Skulls
+--   171941 Blackrock Keg Trap
+--   180391 Heart of Hakkar Spell Emitter
+--   176592 Shellfish Trap
+--   177493 Fire of Elune
+--   177529 Altar of Elune
+--   178124 Resonite Crystal
+--   178248 Naga Brazier
+--   181214 Necropolis critter spawner
+--   184718 Cauldron Summoner
+--   184722 Cauldron Bug Summoner
+--   103575 Containment Coffer TRAP
+--   179324 Frostwolf Landmine
+--   179325 Stormpike Landmine
+UPDATE gameobject_template SET data8=1 WHERE entry IN(128972, 176750, 171941, 180391, 176592, 177493, 177529, 178124, 178248, 181214, 184718, 184722, 103575, 179324, 179325);


### PR DESCRIPTION
Removes the visibility of those objects:
![image](https://user-images.githubusercontent.com/11586807/122620602-a7dd4c00-d093-11eb-9959-6ac472b225c0.png)

Same as already previously suggested here: https://github.com/cmangos/tbc-db/pull/938 
I also added the "Frostwolf Landmine" and "Stormpike Landmine" objects. 

The [solution](https://github.com/cmangos/tbc-db/commit/a0d2500e65e74972197881a2c6ad7eff281b775a) that was applied instead does not work because it uses the `data9` field. Using `data8` as in my suggestions hides those objects to non-GM characters.

@AnonXS 