### PR TITLE
Remove civilian flag from guard

### DIFF
--- a/Updates/0087_theramore_dummy_guard.sql
+++ b/Updates/0087_theramore_dummy_guard.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `ExtraFlags`=2114 WHERE `entry`=4951;


### PR DESCRIPTION
This PR removes the Civilian flag from the guard who is attacking the combat dummies in theramore. If it has this flag it will constantly summon additional guards to also attack the dummy, which is incorrect.

This PR is unrelated to the theramore sparring PR