### PR TITLE
Alterac Valley tweaks

### DIFF
--- a/Updates/9999_alterac_valley_fixes.sql
+++ b/Updates/9999_alterac_valley_fixes.sql
@@ -1,0 +1,36 @@
+-- Missing Spirit Guides in Alliance/Horde caves (coordinates are from mangos-classic)
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (3000616, 13117, 30, 0, 0, -1437.67, -610.089, 51.1619, -0.001854, 120, 120, 0, 0, 1, 0, 0, 0);
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (3000617, 13116, 30, 0, 0, 873.002, -491.284, 96.5419, -0.001854, 120, 120, 0, 0, 1, 0, 0, 0);
+-- Fix mine events (code is from mangos-classic)
+-- Bosses
+UPDATE `battleground_events` SET `event2`='0' WHERE  `map`=30 AND `event1`=46 AND `event2`=1;
+UPDATE `battleground_events` SET `event2`='1' WHERE  `map`=30 AND `event1`=46 AND `event2`=3;
+UPDATE `battleground_events` SET `event2`='2' WHERE  `map`=30 AND `event1`=46 AND `event2`=5;
+UPDATE `battleground_events` SET `event2`='0' WHERE  `map`=30 AND `event1`=47 AND `event2`=1;
+UPDATE `battleground_events` SET `event2`='1' WHERE  `map`=30 AND `event1`=47 AND `event2`=3;
+UPDATE `battleground_events` SET `event2`='2' WHERE  `map`=30 AND `event1`=47 AND `event2`=5;
+-- Creatures
+UPDATE `battleground_events` SET `event2`='0' WHERE  `map`=30 AND `event1`=50 AND `event2`=1;
+UPDATE `battleground_events` SET `event2`='1' WHERE  `map`=30 AND `event1`=50 AND `event2`=3;
+UPDATE `battleground_events` SET `event2`='2' WHERE  `map`=30 AND `event1`=50 AND `event2`=5;
+UPDATE `battleground_events` SET `event2`='0' WHERE  `map`=30 AND `event1`=51 AND `event2`=1;
+UPDATE `battleground_events` SET `event2`='1' WHERE  `map`=30 AND `event1`=51 AND `event2`=3;
+UPDATE `battleground_events` SET `event2`='2' WHERE  `map`=30 AND `event1`=51 AND `event2`=5;
+-- Fix mine creatures
+-- alliance
+UPDATE `creature_battleground` SET `event2`='0' WHERE `event1`=50 AND `event2`=1;
+UPDATE `creature_battleground` SET `event2`='0' WHERE `event1`=51 AND `event2`=1;
+-- horde
+UPDATE `creature_battleground` SET `event2`='1' WHERE `event1`=50 AND `event2`=3;
+UPDATE `creature_battleground` SET `event2`='1' WHERE `event1`=51 AND `event2`=3;
+-- neutral
+UPDATE `creature_battleground` SET `event2`='2' WHERE `event1`=50 AND `event2`=5;
+UPDATE `creature_battleground` SET `event2`='2' WHERE `event1`=51 AND `event2`=5;
+-- boss1
+UPDATE `creature_battleground` SET `event2`='0' WHERE `event1`=46 AND `event2`=1;
+UPDATE `creature_battleground` SET `event2`='1' WHERE `event1`=46 AND `event2`=3;
+UPDATE `creature_battleground` SET `event2`='2' WHERE `event1`=46 AND `event2`=5;
+-- boss2
+UPDATE `creature_battleground` SET `event2`='0' WHERE `event1`=47 AND `event2`=1;
+UPDATE `creature_battleground` SET `event2`='1' WHERE `event1`=47 AND `event2`=3;
+UPDATE `creature_battleground` SET `event2`='2' WHERE `event1`=47 AND `event2`=5;


### PR DESCRIPTION
Alterac Valley for some of issues I came across:
 - Spirit guides are missing in both Alliance & Horde caves (coordinates are from mangos-classic, mangos classic original Horde cave Spirit Guide was in 2.4+ position so I used it here)
 - Fix mine creatures links to BG events. Fix is from cmangos-classic. AV mines only have 3 states - Ally, Horde, Neutral. They don't have contested states and their event IDs depend on TeamIndex (0,1,2). Mangos-classic has these set correctly while tbc/wotlk use some contested-style event IDs (1,3,5) which don't of course.
 - Note: BG mine spawns are still not always correct, but this fix is to restore mine functionality (being captured by killing enemy unique NPC), not to fix spawns.
 - Note: I'm not sure about Spirit Healer GUIDs, I just took those close to other AV spirit guides.