### PR TITLE
Adjust faction and levels of some Lunar Festival Revelers

### DIFF
--- a/Updates/0150_lunar_festival_revelers.sql
+++ b/Updates/0150_lunar_festival_revelers.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_template` SET `Faction`=35 WHERE `Entry` IN (15694, 15719, 15905, 15906, 15907, 15908);
+UPDATE `creature_template` SET `MinLevel`=1 WHERE `Entry`=15906;
+UPDATE `creature_template` SET `MaxLevel`=60 WHERE `Entry`=15694;
+


### PR DESCRIPTION
Lunar Festival Revelers had a wrong faction that allowed the opposite faction to kill them. They should have faction 35, confirmed from sniffs.

Also two had a wrong minlevel and maxlevel. Range for all of them is 1-60.