### PR TITLE
Fix training gossip option text and gossip texts for Undead Priest trainers

### DIFF
--- a/Updates/0161_undead_priest_trainers.sql
+++ b/Updates/0161_undead_priest_trainers.sql
@@ -1,0 +1,5 @@
+UPDATE `gossip_menu_option` SET `option_text`='I seek more training in the priestly ways.', `option_broadcast_text`=7157 WHERE `menu_id` IN (3645, 4531, 4532, 4533, 4543, 4544, 4545) AND `option_id`=5;
+DELETE FROM `gossip_menu_option` WHERE menu_id=4533 AND id=0;
+UPDATE `gossip_menu` SET `condition_id`=0 WHERE `text_id`=4439;
+UPDATE `gossip_menu` SET `condition_id`=112 WHERE `text_id`=4442;
+


### PR DESCRIPTION
Some Undead Priest trainers (like .go creature id 2123) had the wrong default "Train me." option text instead of the correct "I seek more training in the priestly ways.".

They also had their gossip text conditions swapped, showing non-Priest text to Priests and Priest text to non-Priests.

One of them had a "I want to browse your goods." option text as well, which was not used because the NPC is not a trainer.

Valid for WotLK too.