### PR TITLE
Restore missing GossipMenuId for Springspindle Fizzlegear and Trixie Quikswitch

### DIFF
--- a/Updates/0161_gnome_engineers_missing_gossip.sql
+++ b/Updates/0161_gnome_engineers_missing_gossip.sql
@@ -1,0 +1,3 @@
+UPDATE `creature_template` SET `GossipMenuId`=4150 WHERE `Entry`=5174;
+UPDATE `creature_template` SET `GossipMenuId`=4147 WHERE `Entry`=11029;
+


### PR DESCRIPTION
[Springspindle Fizzlegear](https://tbc.wowhead.com/npc=5174/springspindle-fizzlegear) and [Trixie Quikswitch](https://tbc.wowhead.com/npc=11029/trixie-quikswitch) have GossipMenuId=0 in TBC and WotLK. They both should have gossip text.