### PR TITLE
Implement OOC event for Jesthenis Sunstriker and Matron Arena

### DIFF
--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -2881,13 +2881,16 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('1527402','15274','0','0','75','1025','12000','14000','56000','64000','0','0','11','25602','1','0','0','0','0','0','0','0','0','0','Mana Wyrm - Cast Faerie Fire'),
 -- Magistrix Erona (15278) - NSR
 -- Julia Sunstriker (15279) - NSR
--- Jesthenis Sunstriker (15280) - NSR
+-- Jesthenis Sunstriker (15280)
+('1528001','15280','1','0','100','1','5000','8000','5000','8000','0','0','53','10213','0','0','0','0','0','0','0','0','0','0','Jesthenis Sunstriker - Start Relay Script on OOC'),
 -- Lanthan Perilon 15281
 ('1528101','15281','4','0','100','0','0','0','0','0','0','0','57','2','35','0','0','0','0','0','0','0','0','0','Lanthan Perilon - Enable Range Mode on Aggro'),
 ('1528102','15281','2','0','100','1024','15','0','0','0','0','0','25','0','0','0','1','1150','0','0','0','0','0','0','Lanthan Perilon - Flee at 15% HP'),
 ('1528103','15281','9','0','100','1025','0','40','3400','4800','0','0','11','20811','1','256','0','0','0','0','0','0','0','0','Lanthan Perilon - Cast Fireball'),
 -- Summoner Teli'Larien (15283) - NSR
--- Matron Arena (15284) - NSR
+-- Matron Arena (15284)
+('1528401','15284','1','1','100','1','0','2000','0','2000','0','0','53','10214','0','0','22','0','0','0','0','0','0','0','Matron Arena - Start Relay Script and Set Event Phase 0 on OOC (not in event phase 0)'),
+('1528402','15284','30','0','100','1','5','15280','0','0','0','0','22','1','0','0','0','0','0','0','0','0','0','0','Matron Arena - Set Event Phase 1 on Custom Event A received from Jesthenis Sunstriker'),
 -- Pathstalker Kariel (15285) - NSR
 -- Shara Sunwing (15287) - NSR
 -- Raelis Dawnstar (15289) - NSR

--- a/Updates/0161_jesthenis_sunstriker_and_matron_arena.sql
+++ b/Updates/0161_jesthenis_sunstriker_and_matron_arena.sql
@@ -1,0 +1,7 @@
+DELETE FROM `dbscripts_on_relay` WHERE `id` IN (15280, 15281);
+INSERT INTO `dbscripts_on_relay` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(10213, 0, 1, 31, 15284, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jesthenis Sunstriker - Terminate script if NPC Matron Arena not found'),
+(10213, 0, 2, 1, 1, 0, 0, 0, 0, 0, 6, 273, 274, 0, 0, 0, 0, 0, 0, 'Jesthenis Sunstriker - Play Random Emote (Talk, Question, Yes or No)'),
+(10213, 0, 3, 35, 5, 0, 0, 15284, 20, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Jesthenis Sunstriker - Send Custom Event A to Matron Arena'),
+(10214, 0, 0, 1, 1, 0, 0, 0, 0, 0, 6, 273, 274, 0, 0, 0, 0, 0, 0, 'Matron Arena - Play Random Emote (Talk, Question, Yes or No)');
+


### PR DESCRIPTION
Original implementation from TrinityCore, checked on TBC PTR. [Jesthenis Sunstriker](https://tbc.wowhead.com/npc=15280/jesthenis-sunstriker) does an emote out of four possibilities, then between 0 and 2000 ms later [Matron Arena](https://tbc.wowhead.com/npc=15284/matron-arena) replies with a random emote out of the same four possibilities.