### PR TITLE
Fix condition for Warrior-only gossip text of Draenei Warrior trainers

### DIFF
--- a/Updates/0161_draenei_warrior_trainer_gossip_text.sql
+++ b/Updates/0161_draenei_warrior_trainer_gossip_text.sql
@@ -1,0 +1,2 @@
+UPDATE `gossip_menu` SET `condition_id`=13 WHERE `entry`=7263 AND `text_id`=8587;
+


### PR DESCRIPTION
[Kore](https://tbc.wowhead.com/npc=16503/kore) and other Draenei Warrior trainers were showing non-Warrior gossip text to Warriors, because that text's condition was checking for racemask 1, not classmask 1.