### PR TITLE
Improve OOC event for General Krakork in Thrallmar

### DIFF
--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -17456,7 +17456,7 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('1925301','19253','30','0','100','1','5','16580','0','0','0','0','18','33536','10','0','0','0','0','0','0','0','0','0','Lieutenant General Orion - change targets unitFlag on Receive AI Event A'),
 ('1925302','19253','30','0','100','1','6','16582','0','0','0','0','18','768','10','0','0','0','0','0','0','0','0','0','Lieutenant General Orion - change targets unitFlag on Receive AI Event B'),
 -- General Krakork
-('1925501','19255','1','0','100','1','150000','150000','150000','150000','0','0','1','16391','16392','16390','5','5','0','0','0','0','0','0','General Krakork - Random Gossip Speech and Emote'),
+('1925501','19255','1','0','100','1','90000','120000','90000','120000','0','0','53','10215','0','0','0','0','0','0','0','0','0','0','General Krakork - Start Relay Script on OOC'),
 -- Arcanist Torseldori 19257
 ('1925701','19257','4','0','100','0','0','0','0','0','0','0','57','2','35','0','0','0','0','0','0','0','0','0','Arcanist Torseldori - Enable Range Mode on Aggro'),
 ('1925702','19257','0','0','100','1025','8000','12000','11000','22000','0','0','11','22272','1','0','0','0','0','0','0','0','0','0','Arcanist Torseldori - Cast Arcane Missiles'),

--- a/Updates/0161_general_krakork.sql
+++ b/Updates/0161_general_krakork.sql
@@ -1,0 +1,19 @@
+DELETE FROM `dbscripts_on_relay` WHERE `id`=10215;
+INSERT INTO `dbscripts_on_relay` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(10215, 0, 1, 31, 16580, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Terminate script if NPC Thrallmar Grunt is not found'),
+(10215, 0, 2, 32, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Pause Waypoint Movement'),
+(10215, 0, 3, 36, 0, 0, 0, 16580, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Face Nearest Thrallmar Grunt'),
+(10215, 1700, 0, 0, 10085, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Say Random Text'),
+(10215, 4700, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Play Emote Talk'),
+(10215, 9700, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'General Krakork - Unpause Waypoint Movement');
+
+DELETE FROM `dbscript_random_templates` WHERE `id`=10085;
+INSERT INTO `dbscript_random_templates` (`id`, `type`, `target_id`, `chance`, `comments`) VALUES
+(10085, 0, 16390, 0, 'General Krakork - OOC Texts'),
+(10085, 0, 16391, 0, 'General Krakork - OOC Texts'),
+(10085, 0, 16392, 0, 'General Krakork - OOC Texts'),
+(10085, 0, 16393, 0, 'General Krakork - OOC Texts'),
+(10085, 0, 16394, 0, 'General Krakork - OOC Texts');
+
+UPDATE `broadcast_text` SET `EmotesID`=1 WHERE `Id` BETWEEN 16390 AND 16394;
+


### PR DESCRIPTION
[General Krakork](https://tbc.wowhead.com/npc=19255/general-krakork) was missing two random texts. Also he should stop, turn toward the nearest guard, talk and then resume movement. Before he only had a talk event on a timer.