### PR TITLE
Fix Vizzklick's gossip text for players without Tailoring

### DIFF
--- a/Updates/0168_vizzklick_gossip_text.sql
+++ b/Updates/0168_vizzklick_gossip_text.sql
@@ -1,0 +1,6 @@
+UPDATE `gossip_menu` SET `condition_id`=1605 WHERE `entry`=1301 AND `text_id`=1934;
+
+DELETE FROM `conditions` WHERE `condition_entry`=1605;
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`, `value3`, `value4`, `flags`, `comments`) VALUES
+(1605, 7, 197, 230, 0, 0, 0, 'Has Tailoring at 230 or above');
+


### PR DESCRIPTION
[Vizzklick](https://www.wowhead.com/npc=6568/vizzklick) in Gadgetzan has a gossip text for those with Tailoring that sends you to a questgiver in Searing Gorge. Right now that gossip is shown even if you don't have Tailoring.

Valid for Vanilla, TBC and WotLK.