### PR TITLE
Remove wrong gossip flag from Arena Season 3 version of Evee Copperspring

### DIFF
--- a/Updates/0168_evee_copperspring_gossip_flag.sql
+++ b/Updates/0168_evee_copperspring_gossip_flag.sql
@@ -1,0 +1,2 @@
+UPDATE `creature_template` SET `NpcFlags`=`NpcFlags`&~1 WHERE `Entry`=25177;
+


### PR DESCRIPTION
[Evee Copperspring](https://tbc.wowhead.com/npc=25177/evee-copperspring) (Arena Season 3 version) has gossip flag, but she shouldn't have it. The Arena Season 4 version doesn't have it.

Valid for TBC and WotLK.