### PR TITLE
Add gossip text condition for Linken

### DIFF
--- a/Updates/0168_linken_gossip_text.sql
+++ b/Updates/0168_linken_gossip_text.sql
@@ -1,0 +1,5 @@
+UPDATE `gossip_menu` SET `condition_id`=1606 WHERE `entry`=1961 AND `text_id`=2634;
+DELETE FROM `conditions` WHERE `condition_entry`=1606;
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`, `value3`, `value4`, `flags`, `comments`) VALUES
+(1606, 8, 3845, 0, 0, 0, 0, 'Quest \'It\'s a Secret to Everybody\' is rewarded');
+


### PR DESCRIPTION
[Linken](https://tbc.wowhead.com/npc=8737/linken) has two gossip texts: one before and one after the quest [It's a Secret to Everybody](https://tbc.wowhead.com/quest=3845/its-a-secret-to-everybody) (Part 2) is rewarded. He was showing only the second one. Verified on TBC PTR that it's that exact quest, because I found conflicting info on Wowhead.

Valid for Vanilla, TBC and WotLK.