### PR TITLE
Quest Bungle in the Jungle requires quest March of the Silithid rewarded

### DIFF
--- a/Updates/0168_quest_bungle_in_the_jungle_quest_requirements.sql
+++ b/Updates/0168_quest_bungle_in_the_jungle_quest_requirements.sql
@@ -1,0 +1,8 @@
+UPDATE `quest_template` SET `RequiredCondition`=1609 WHERE `entry`=4496;
+
+DELETE FROM `conditions` WHERE `condition_entry` IN (1607, 1608, 1609);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`, `value3`, `value4`, `flags`, `comments`) VALUES
+(1607, 8, 4493, 0, 0, 0, 0, 'Quest \'March of the Silithid\' (Alliance) is rewarded'),
+(1608, 8, 4494, 0, 0, 0, 0, 'Quest \'March of the Silithid\' (Horde) is rewarded'),
+(1609, -2, 1607, 1608, 0, 0, 0, 'Quest \'March of the Silithid\' (Horde or Alliance) is rewarded');
+


### PR DESCRIPTION
The quest [Bungle in the Jungle](https://tbc.wowhead.com/quest=4496/bungle-in-the-jungle) requires March of the Silithid ([Alliance](https://tbc.wowhead.com/quest=4493/march-of-the-silithid), [Horde](https://tbc.wowhead.com/quest=4494/march-of-the-silithid)) rewarded. [Proof](https://classic.wowhead.com/quest=4496/bungle-in-the-jungle#comments:id=5155618).

This quest is not a breadcrumb, it's actually required.

Valid for Vanilla, TBC and WotLK.