### PR TITLE
Add requirements to the March of the Silithid quests

### DIFF
--- a/Updates/0168_march_of_the_silithid_quest_requirements.sql
+++ b/Updates/0168_march_of_the_silithid_quest_requirements.sql
@@ -1,0 +1,12 @@
+UPDATE `quest_template` SET `RequiredCondition`=1612 WHERE `entry`=4493;
+UPDATE `quest_template` SET `RequiredCondition`=1615 WHERE `entry`=4494;
+
+DELETE FROM `conditions` WHERE `condition_entry` BETWEEN 1610 AND 1615;
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`, `value3`, `value4`, `flags`, `comments`) VALUES
+(1610, 8, 162, 0, 0, 0, 0, 'Quest \'Rise of the Silithid\' (Alliance) is rewarded'),
+(1611, 8, 4267, 0, 0, 0, 0, 'Quest \'Rise of the Silithid\' is rewarded'),
+(1612, -2, 1610, 1611, 0, 0, 0, 'Quest \'Rise of the Silithid\' (4267) or \'Rise of the Silithid\' (162) is rewarded'),
+(1613, 8, 32, 0, 0, 0, 0, 'Quest \'Rise of the Silithid\' (Horde) is rewarded'),
+(1614, 8, 7732, 0, 0, 0, 0, 'Quest \'Zukk\'ash Report\' is rewarded'),
+(1615, -2, 1613, 1614, 0, 0, 0, 'Quest \'Rise of the Silithid\' or \'Zukk\'ash Report\' is rewarded');
+


### PR DESCRIPTION
The March of the Silithid quests ([Alliance](https://tbc.wowhead.com/quest=4493/march-of-the-silithid), [Horde](https://tbc.wowhead.com/quest=4494/march-of-the-silithid)) aren't available without finishing some other quests first. Which quests exactly is not trivial to say, because there are a lot of conflicting reports ([here's the most relevant one I found](https://tbc.wowhead.com/quest=4494/march-of-the-silithid#comments:id=2962966:reply=1341582)).

This leads me to believe that there are two potential prerequisites, and you have to finish one or the other.

The most likely candidates are [Rise of the Silithid](https://tbc.wowhead.com/quest=162) or [Rise of the Silithid](https://tbc.wowhead.com/quest=4267) (Alliance. Same name, but two different quest chains) and [Rise of the Silithid](https://tbc.wowhead.com/quest=32/rise-of-the-silithid) or [Zukk'ash Report](https://tbc.wowhead.com/quest=7732/zukkash-report) (Horde), mostly because they end at the same questgivers of the March of the Silithid quests and they fit the criteria of "Silithid quests in other areas".