### PR TITLE
Add missing Stranglethorn Vale random fishing pool to its spawn_group id

### DIFF
--- a/Updates/0168_add_missing_stranglethorn_vale_spawn_group_spawn.sql
+++ b/Updates/0168_add_missing_stranglethorn_vale_spawn_group_spawn.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spawn_group_spawn` WHERE `guid`=1080116;
+INSERT INTO `spawn_group_spawn` (`Id`, `Guid`, `SlotId`) VALUES
+(9009, 1080116, -1);
+


### PR DESCRIPTION
Fixes the error
```
Gameobject (GUID: 1080116) not created: Entry 0 does not exist in `gameobject_template`. Map: 0  (X: -13185.799805 Y: 700.265991 Z: 0.000000) ang: 2.635440 rotation0: 0.000000 rotation1: 0.000000 rotation2: 0.968147 rotation3: 0.250381
```