### PR TITLE
Fix duration of item Gnome/Goblin Engineer Membership Card

### DIFF
--- a/Updates/0171_engineering_membership_cards_duration.sql
+++ b/Updates/0171_engineering_membership_cards_duration.sql
@@ -1,2 +1,2 @@
-UPDATE `item_template` SET `Duration`=1209600, `ExtraFlags`=2 WHERE `entry` IN (10790, 10791);
+UPDATE `item_template` SET `Duration`=1209600, `ExtraFlags`=1 WHERE `entry` IN (10790, 10791);
 

--- a/Updates/0171_engineering_membership_cards_duration.sql
+++ b/Updates/0171_engineering_membership_cards_duration.sql
@@ -1,0 +1,2 @@
+UPDATE `item_template` SET `Duration`=1209600, `ExtraFlags`=2 WHERE `entry` IN (10790, 10791);
+


### PR DESCRIPTION
The items ([Gnome Engineer Membership Card](https://tbc.wowhead.com/item=10790/gnome-engineer-membership-card) and [Goblin Engineer Membership Card](https://tbc.wowhead.com/item=10791/goblin-engineer-membership-card)) should last 14 days and the timer should keep ticking even while offline.

The current value is wrong and causes the duration to overflow, and it doesn't tick while offline.