### PR TITLE
Add some known serverside cooldowns to charmed spells

### DIFF
--- a/Updates/0175_charmed_spell_cooldowns.sql
+++ b/Updates/0175_charmed_spell_cooldowns.sql
@@ -1,0 +1,4 @@
+UPDATE `spell_template` SET `RecoveryTime`=30000 WHERE `Id`=13398;
+UPDATE `spell_template` SET `RecoveryTime`=60000 WHERE `Id`=34019;
+UPDATE `spell_template` SET `RecoveryTime`=10000 WHERE `Id`=34073;
+


### PR DESCRIPTION
A lot of spells useable by charming a creature via Mind Control have no cooldown in DBC, but have a cooldown when actually used on retail.

This cooldown seems to be activated even when the creature itself uses the spell before being charmed. So the spells actually have cooldown, it just wasn't added to client's DBC files for whatever reason.

I was hoping to find a common link between those spells so that all cases could be fixed at once, but alas, it seems each spell uses a separate specific cooldown and it's not generalized.

I will add more as I find out the correct values. If anyone knows other values, they're welcome to add to this!

ToDo:

- [ ] Bleeding Hollow Necrolyte 19422
- [ ] Bonechewer Scavenger 18952
- [ ] Phantom Valet 16408
- [ ] Leprous Machinesmith 6224
- [ ] Leprous Technician 6222

research:
```
-- ('1895203','18952','0','13','100','1024','1000','3000','0','0','0','0','11','13398','1','0','0','0','0','0','0','0','0','0','Bonechewer Scavenger - Cast Throw Wrench (Phase 1)'),
-- ('622206','6222','9','0','100','1025','5','30','1200','2500','0','0','11','13398','1','256','0','0','0','0','0','0','0','0','Leprous Technician - Cast Throw Wrench'),
-- ('622406','6224','9','0','100','1025','5','30','1200','2500','0','0','11','13398','1','256','0','0','0','0','0','0','0','0','Leprous Machinesmith - Cast Throw Wrench'),
UPDATE `creature_template` SET `SpellList` = (`entry` * 100 + 1) WHERE `entry` IN (6222,6224,18952);
DELETE FROM `creature_spell_list` WHERE `Id` IN (622201,622401,1895201);
INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES
(622201, 0, 13398, 2, 1, 0, 100, 1, 0, 1000, 2000, 4000, 'Leprous Technician - Cast Throw Wrench'),
(622401, 0, 13398, 2, 1, 0, 100, 1, 0, 1000, 2000, 4000, 'Leprous Machinesmith - Cast Throw Wrench'),
(1895201, 0, 13398, 0, 1, 0, 100, 1, 0, 1000, 30000, 30000, 'Bonechewer Scavenger - Cast Throw Wrench');

-- ('1942202','19422','0','0','100','1025','8000','12000','15000','20000','0','0','11','34019','0','0','0','0','0','0','0','0','0','0','Bleeding Hollow Necrolyte - Cast Raise Dead'),


```