### PR TITLE
[Creature] Correct UnitFlags for shadowpine hexxer so they become interactive

### DIFF
--- a/Updates/0256_shadowpinehexxer_fix_flags.sql
+++ b/Updates/0256_shadowpinehexxer_fix_flags.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `UnitFlags`=32768 WHERE `Entry`=16346;


### PR DESCRIPTION
Shadowpine Hexxer (quest target creature) is non-interactable due to incorrect Unitflags been applied to it
Fixes shadowpine hexxer so it has the same UnitFlags as other shadowpine mobs it spawns with.