### PR TITLE
Make flag BG auras proc from non dmg spells too

### DIFF
--- a/Updates/0298_bg_flag_procs.sql
+++ b/Updates/0298_bg_flag_procs.sql
@@ -1,0 +1,6 @@
+-- should proc from non dmg - applicable to tbc and wotlk
+DELETE FROM spell_proc_event WHERE entry IN(23333,23335,34976);
+INSERT INTO spell_proc_event(entry, procEx) VALUES
+(23333,65536),
+(23335,65536),
+(34976,65536);


### PR DESCRIPTION
Ports https://github.com/cmangos/wotlk-db/commit/29154f6be37ce136cd9a69b2e92e9981d2684fe7 to TBC.

Related PR: https://github.com/cmangos/mangos-tbc/pull/546

Co-Authored-By: killerwife <killerwife@users.noreply.github.com>