### PR TITLE
You can now apply the core updates in non-interactive mode.

### DIFF
--- a/InstallFullDB.sh
+++ b/InstallFullDB.sh
@@ -2782,6 +2782,21 @@ function auto_script_install_world()
   true
 }
 
+# apply core updates using config file settings and normal user
+function auto_script_apply_core_update()
+{
+  show_mysql_settings
+  echo
+  echo "Applying all the latest core updates..."
+
+  if ! apply_core_update; then
+    false
+    return
+  fi
+
+  true
+}
+
 # do a backup
 function auto_script_backup()
 {
@@ -2903,6 +2918,14 @@ fi
 # check if user only want to install world db using config
 if [[ "$1" = "-World" ]]; then
   if ! auto_script_install_world; then
+    exit 1
+  fi
+
+  exit 0
+fi
+# only apply core updates using config
+if [[ "$1" = "-UpdateCore" ]]; then
+  if ! auto_script_apply_core_update; then
     exit 1
   fi
 


### PR DESCRIPTION
Hi! 👋

I was trying to "wrap" the database update process with a script of mine that does some further actions...  
A more complex one to integrate some other stuff...

I found out that the [`InstallFullDB.sh`](https://github.com/cmangos/tbc-db/blob/master/InstallFullDB.sh) partially supports running as a non-interactive script by allowing the user to specify some options...
In particular, one of these options is `-World`.

I've successfully used it to perform the database update process **BUT**...
In some cases, it seems to be not enough to properly start the server as it keeps asking for more updates to be applied.
When it happens, I'm forced to run the `InstallFullDB.sh` interactively and manually select the option #3:  
`Install core updates only`.

With this PR, I want to add to this script the ability to execute this last option in non-interactive mode specifying the option:  
`-UpdateCore`.

Nothing less... Nothing more...  
Just few lines of code.

---

If this PR looks good to you, I'd be happy to be a contributor for the other 2 DB repos ([`classic-db`](https://github.com/cmangos/classic-db) and [`wotlk-db`](https://github.com/cmangos/wotlk-db)) with the same PR as well.

Waiting for your OK to open the others too... 🙃