### PR TITLE
Fix startup errors for creature_spawn_data_template

### DIFF
--- a/Updates/0707_world_dberrors.sql
+++ b/Updates/0707_world_dberrors.sql
@@ -1,0 +1,129 @@
+-- Fix some DB errors
+
+UPDATE creature_spawn_data_template SET Name = 'GENERIC - NpcFlags' WHERE Entry = '4';
+UPDATE creature_spawn_data_template SET Name = 'GENERIC - EquipmentId' WHERE Entry = '5';
+UPDATE creature_spawn_data_template SET Name = 'Quest:The Binding: Summoned Voidwalker - RelayScript' WHERE Entry = '5676';
+UPDATE creature_spawn_data_template SET Name = 'Quest:The Binding: Summoned Felhunter - RelayScript' WHERE Entry = '6268';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7461';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7462';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7463';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7464';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7465';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7466';
+UPDATE creature_spawn_data_template SET Name = 'The Madness Within: Shen\'dralar Ancient - RelayScript' WHERE Entry = '7467';
+UPDATE creature_spawn_data_template SET Name = 'Defias Rioter - RelayScript' WHERE Entry = '9999';
+UPDATE creature_spawn_data_template SET Name = 'Dark Iron Antagonist - UnitFlags and Faction' WHERE Entry = '10000';
+UPDATE creature_spawn_data_template SET Name = 'Mutant War Hound - UnitFlags' WHERE Entry = '10001';
+-- Bonechewer Blood Prophet, Bonechewer Shield Disciple, Bonechewer Blade Fury - UnitFlags
+UPDATE creature_spawn_data_template SET Name = 'BT: Bonechewer NPCs - UnitFlags' WHERE Entry = '10002';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - ModelId' WHERE Entry = '10003'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Cork Gizelton - RelayScript' WHERE Entry = '11625';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19985';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19986';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19987';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19988';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19989';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19990';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19991';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19992';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19993';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19994';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19995';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19996';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19997';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19998';
+UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19999';
+-- Orgrimmar Peon, Peon Overseer
+UPDATE creature_spawn_data_template SET Name = 'Orgrimmar Peon | Peon Overseer - RelayScript' WHERE Entry = '20033';
+UPDATE creature_spawn_data_template SET Name = 'Orgrimmar Peon | Peon Overseer - RelayScript' WHERE Entry = '20034';
+UPDATE creature_spawn_data_template SET Name = 'Flawless Draenethyst Fragment - RelayScript' WHERE Entry = '25210';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25210';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25211';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25212';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25213';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25214';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25215';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25216';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25217';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25218';
+UPDATE creature_spawn_data_template SET Name = 'Draenei Refugee - RelayScript' WHERE Entry = '25219';
+UPDATE creature_spawn_data_template SET Name = 'Plaque Spreader - Faction' WHERE Entry = '60401';
+UPDATE creature_spawn_data_template SET Name = 'Hammerfall Guardian - Equipment' WHERE Entry = '262101';
+UPDATE creature_spawn_data_template SET Name = 'Crimson Guardsman - Faction' WHERE Entry = '1041801';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1484901'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1484902'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Darkmoon Faire Carnie - Equipment' WHERE Entry = '1484903';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1490101'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Peon - Equipment' WHERE Entry = '1490102';
+UPDATE creature_spawn_data_template SET Name = 'Peon - Equipment' WHERE Entry = '1490103';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1490104'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1490105'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658001'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Thrallmar Grunt - Equipment' WHERE Entry = '1658002';
+UPDATE creature_spawn_data_template SET Name = 'Thrallmar Grunt - Equipment' WHERE Entry = '1658003';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658004'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658005'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658006'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658007'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Thrallmar Marksman - Equipment' WHERE Entry = '1658201'; 
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658202'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1658203'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Thrallmar Grunt - Equipment' WHERE Entry = '1658204'; 
+UPDATE creature_spawn_data_template SET Name = 'Nethergarde Infantry - Equipment' WHERE Entry = '1683101'; 
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683102'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683103'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683104'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683105'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683106'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683107'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683108'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683109'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1683110'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684201'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684202'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684203'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684204'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684205'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1684206'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686401'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686402'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Honor Hold Defender - Equipment' WHERE Entry = '1686403'; 
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686404'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686405'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686406'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686407'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686408'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - Equipment' WHERE Entry = '1686409'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Boulderfist Crusher - RelayScript' WHERE Entry = '1713401';
+UPDATE creature_spawn_data_template SET Name = 'Siltfin Oracle - RelayScript' WHERE Entry = '1719101';
+UPDATE creature_spawn_data_template SET Name = 'Bonechewer Hungerer - RelayScript' WHERE Entry = '1725901';
+UPDATE creature_spawn_data_template SET Name = 'Bonechewer Ravener - RelayScript' WHERE Entry = '1726401';
+UPDATE creature_spawn_data_template SET Name = 'Blacksilt Shorestriker - RelayScript' WHERE Entry = '1732801';
+UPDATE creature_spawn_data_template SET Name = 'Coilfang Engineer - RelayScript' WHERE Entry = '1772101';
+UPDATE creature_spawn_data_template SET Name = 'Expedition Warden - EquipmentId' WHERE Entry = '1785501';
+UPDATE creature_spawn_data_template SET Name = 'Mug\'gok - RelayScript' WHERE Entry = '1847501';
+UPDATE creature_spawn_data_template SET Name = 'Telaari Watcher - RelayScript' WHERE Entry = '1848801';
+UPDATE creature_spawn_data_template SET Name = 'Scryer Arcanist - RelayScript' WHERE Entry = '1854701';
+UPDATE creature_spawn_data_template SET Name = 'Worker - EquipmentId' WHERE Entry = '1880001';
+UPDATE creature_spawn_data_template SET Name = 'Telaari Elekk Rider - RelayScript' WHERE Entry = '1907101';
+UPDATE creature_spawn_data_template SET Name = 'Kor\'kron Defender - RelayScript' WHERE Entry = '1936201';
+UPDATE creature_spawn_data_template SET Name = 'Coilskar Myrmidon - EquipmentId' WHERE Entry = '1976501';
+UPDATE creature_spawn_data_template SET Name = 'Nether Technician - EquipmentId' WHERE Entry = '2020301';
+UPDATE creature_spawn_data_template SET Name = 'Unknown - EquipmentId' WHERE Entry = '2020302'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Unknown - EquipmentId' WHERE Entry = '2020303'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'Greyheart-Nether-Mage | Greyheart Tidecalle - RelayScript' WHERE Entry = '2122901';
+UPDATE creature_spawn_data_template SET Name = 'Greyheart Skulker - RelayScript' WHERE Entry = '2123201';
+UPDATE creature_spawn_data_template SET Name = 'Ethereal Plunderer - EquipmentId' WHERE Entry = '2136801';
+UPDATE creature_spawn_data_template SET Name = 'Ethereal Nethermancer - EquipmentId' WHERE Entry = '2137001';
+UPDATE creature_spawn_data_template SET Name = 'Ethereal Arcanist - EquipmentId' WHERE Entry = '2140501';
+UPDATE creature_spawn_data_template SET Name = 'Sunfury Eradicator - RelayScript' WHERE Entry = '2174201';
+UPDATE creature_spawn_data_template SET Name = 'Skettis Soulcaller - EquipmentId' WHERE Entry = '2191101';
+UPDATE creature_spawn_data_template SET Name = 'Eclipsion Soldier - RelayScript' WHERE Entry = '2201601';
+UPDATE creature_spawn_data_template SET Name = 'Eclipsion Cavalier - RelayScript' WHERE Entry = '2201801';
+UPDATE creature_spawn_data_template SET Name = 'Dragonmaw Peon - EquipmentId' WHERE Entry = '2225201';
+UPDATE creature_spawn_data_template SET Name = 'Dragonmaw Ascendant - RelayScript' WHERE Entry = '2225301';
+UPDATE creature_spawn_data_template SET Name = 'Skyguard Navigator - EquipmentId' WHERE Entry = '2298201';
+UPDATE creature_spawn_data_template SET Name = 'Dragonmaw Enforcer - RelayScript' WHERE Entry = '2314601';
+UPDATE creature_spawn_data_template SET Name = 'Skyguard Windcharger - EquipmentId' WHERE Entry = '2325701';
+UPDATE creature_spawn_data_template SET Name = 'Murkblood Miner - UnitFlags' WHERE Entry = '2328701';
+UPDATE creature_spawn_data_template SET Name = 'Amani\'shi Guardian - RelayScript' WHERE Entry = '2359701';

--- a/Updates/0707_world_dberrors.sql
+++ b/Updates/0707_world_dberrors.sql
@@ -16,7 +16,7 @@ UPDATE creature_spawn_data_template SET Name = 'Dark Iron Antagonist - UnitFlags
 UPDATE creature_spawn_data_template SET Name = 'Mutant War Hound - UnitFlags' WHERE Entry = '10001';
 -- Bonechewer Blood Prophet, Bonechewer Shield Disciple, Bonechewer Blade Fury - UnitFlags
 UPDATE creature_spawn_data_template SET Name = 'BT: Bonechewer NPCs - UnitFlags' WHERE Entry = '10002';
-UPDATE creature_spawn_data_template SET Name = 'Unknown - ModelId' WHERE Entry = '10003'; -- no data in creature_spawn_data
+UPDATE creature_spawn_data_template SET Name = 'World Invisible Trigger - ModelId' WHERE Entry = '10003'; -- used on dscripts_on_event id 14143
 UPDATE creature_spawn_data_template SET Name = 'Cork Gizelton - RelayScript' WHERE Entry = '11625';
 UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19985';
 UPDATE creature_spawn_data_template SET Name = 'Stillpine Captive - RelayScript' WHERE Entry = '19986';


### PR DESCRIPTION
This fix all 'creature_spawn_data_template for entry x has empty name' startup errors. 
Some are unkown (no data in creature_spawn_data and didnt found them in dbscripts.)

Still get
Table reference_loot_template_names for entry xy has name but no entry

errors on startup.