### PR TITLE
[Karazhan] Add Moroes'Guests to spell_list

### DIFF
--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -28353,11 +28353,11 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('1825402','18254','9','0','100','1057','0','100','3000','3000','0','0','11','29957','0','256','11','29958','0','256','11','29960','0','256','Shadow of Aran - Cast Frostbolt Volley or Fireball Volley or Arcane Missile Volley'),
 -- Lady Catriona Von'Indi 19872 - spell_list
 -- Lord Crispin Ference 19873 - spell_list
--- Baron Rafe Dreuger 19874 - spell_list
 ('1987301','19873','2','0','100','0','20','0','0','0','0','0','11','29390','0','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Shield Wall at 20%'),
+-- Baron Rafe Dreuger 19874 - spell_list
 -- Baroness Dorothea Millstipe 19875 - spell_lists
 ('1987501','19875','27','0','100','1','29406','1','1500','8000','1','0','11','29406','0','0','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Shadowform on Aura Missing'),
--- Lord Robin Daris -- spell_list
+-- Lord Robin Daris - spell_list
 -- Conjured Water Elemental (21160) - npc_water_elemental
 -- Human Charger (21664) - npc_human_charger
 -- Human Cleric (21682) - npc_human_cleric

--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -28356,7 +28356,7 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 ('1987301','19873','2','0','100','0','20','0','0','0','0','0','11','29390','0','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Shield Wall at 20%'),
 -- Baron Rafe Dreuger 19874 - spell_list
 -- Baroness Dorothea Millstipe 19875 - spell_lists
-('1987501','19875','27','0','100','1','29406','1','1500','8000','1','0','11','29406','0','0','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Shadowform on Aura Missing'),
+('1987501','19875','0','0','100','1','1500','8000','1500','8000','1','0','11','29406','0','32','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Shadowform on Aura Missing'),
 -- Lord Robin Daris - spell_list
 -- Conjured Water Elemental (21160) - npc_water_elemental
 -- Human Charger (21664) - npc_human_charger

--- a/ACID/acid_tbc.sql
+++ b/ACID/acid_tbc.sql
@@ -28269,12 +28269,8 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 -- Gradav (16814) - NSR
 -- Kamsis (16815) - NSR
 -- Echo of Medivh (16816) - npc_echo_of_medivh
--- Lady Keira Berrybuck 17007
-('1700701','17007','4','0','100','0','0','0','0','0','0','0','11','29381','0','0','0','0','0','0','0','0','0','0','Lady Keira Berrybuck - Cast Greater Blessing of Might on Aggro'),
-('1700702','17007','0','0','100','1025','5000','14000','18000','30000','0','0','11','29382','0','0','0','0','0','0','0','0','0','0','Lady Keira Berrybuck - Cast Divine Shield'),
-('1700703','17007','16','0','100','1025','29381','30','8000','16000','0','0','11','29381','12','0','0','0','0','0','0','0','0','0','Lady Keira Berrybuck - Cast Greater Blessing of Might on Friendly Missing Buff'),
-('1700704','17007','14','0','100','1025','4000','30','7000','13000','0','0','11','29380','12','0','0','0','0','0','0','0','0','0','Lady Keira Berrybuck - Cast Cleanse on Friendly Missing HP'),
-('1700705','17007','14','0','100','1057','8000','40','10000','15000','0','0','11','29383','12','0','11','29562','12','0','0','0','0','0','Lady Keira Berrybuck - Random Cast Holy Light or Holy Light on Friendly Missing HP'),
+-- Lady Keira Berrybuck 17007 -- spell_list
+('1700701','17007','2','0','100','1024','10','0','0','0','0','0','11','29382','0','0','11','29383','0','0','0','0','0','0','Lady Keira Berrybuck - Cast Divine Shield and Holy Lighton at 10%'),
 -- Phantom Hound - creature_spell_list
 ('1706702','17067','6','0','100','0','0','0','0','0','0','0','11','29541','0','7','0','0','0','0','0','0','0','0','Phantom Hound - Cast Summon Phantom Hound Visual on Death'),
 -- Astral Flare 17096 + 19781 + 19782 + 19783
@@ -28355,29 +28351,13 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 -- Shadow of Aran 18254
 ('1825401','18254','11','0','100','0','0','0','0','0','0','0','57','1','95','0','0','0','0','0','0','0','0','0','Shadow of Aran - Enable Caster Mode on Spawn'),
 ('1825402','18254','9','0','100','1057','0','100','3000','3000','0','0','11','29957','0','256','11','29958','0','256','11','29960','0','256','Shadow of Aran - Cast Frostbolt Volley or Fireball Volley or Arcane Missile Volley'),
--- Lady Catriona Von'Indi 19872
-('1987201','19872','0','0','100','1025','1000','3000','15000','25000','0','0','11','29408','0','32','0','0','0','0','0','0','0','0','Lady Catriona Von''Indi - Cast Power Word: Shield'),
-('1987202','19872','14','0','100','1025','0','40','4000','9000','0','0','11','29564','12','0','0','0','0','0','0','0','0','0','Lady Catriona Von''Indi - Cast Greater Heal on Friendly Missing HP'),
-('1987203','19872','14','0','100','1025','0','30','3000','6000','0','0','11','15090','12','0','0','0','0','0','0','0','0','0','Lady Catriona Von''Indi - Cast Dispel Magic on Friendly Missing HP'),
-('1987204','19872','9','0','100','1025','0','30','5000','10000','0','0','11','15090','4','512','0','0','0','0','0','0','0','0','Lady Catriona Von''Indi - Cast Dispel Magic'),
-('1987205','19872','0','0','100','1025','5000','7000','17000','22000','0','0','11','29563','4','512','0','0','0','0','0','0','0','0','Lady Catriona Von''Indi - Cast Holy Fire'),
--- Lord Crispin Ference 19873
-('1987301','19873','0','0','100','1025','6000','7000','10000','12000','0','0','11','8379','1','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Disarm'),
-('1987302','19873','0','0','100','1025','8000','10000','7000','11000','0','0','11','29567','1','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Heroic Strike'),
-('1987303','19873','0','0','100','1025','7000','9000','11000','14000','0','0','11','11972','4','2048','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Shield Bash on Casting'),
-('1987304','19873','0','0','100','1025','1000','3000','18000','25000','0','0','11','29390','0','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Shield Wall'),
--- Baron Rafe Dreuger 19874
-('1987401','19874','0','0','100','1025','20000','35000','30000','50000','0','0','11','13005','1','0','0','0','0','0','0','0','0','0','Baron Rafe Dreuger - Cast Hammer of Justice'),
-('1987402','19874','0','0','100','1025','25000','30000','25000','30000','0','0','11','29386','1','0','0','0','0','0','0','0','0','0','Baron Rafe Dreuger - Cast Judgement of Command'),
-('1987403','19874','0','0','100','1025','7000','9000','30000','35000','0','0','11','29385','0','0','0','0','0','0','0','0','0','0','Baron Rafe Dreuger - Cast Seal of Command'),
--- Baroness Dorothea Millstipe 19875
-('1987501','19875','1','0','100','0','0','0','0','0','0','0','11','29406','0','0','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Shadowform OOC'),
-('1987502','19875','0','0','100','1025','7000','8000','5000','10000','0','0','11','29405','16','512','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Mana Burn on Random Player Mana User'),
-('1987503','19875','9','0','100','1025','0','20','5000','12000','0','0','11','29570','4','512','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Mind Flay'),
--- Lord Robin Daris
-('1987601','19876','9','0','100','1025','0','5','7000','11000','0','0','11','9080','1','0','0','0','0','0','0','0','0','0','Lord Robin Daris - Cast Hamstring'),
-('1987602','19876','0','0','100','1025','8000','10000','11000','14000','0','0','11','29572','1','0','0','0','0','0','0','0','0','0','Lord Robin Daris - Cast Mortal Strike'),
-('1987603','19876','0','0','100','1025','5000','9000','8000','13000','0','0','11','29573','0','0','0','0','0','0','0','0','0','0','Lord Robin Daris - Cast Whirlwind'),
+-- Lady Catriona Von'Indi 19872 - spell_list
+-- Lord Crispin Ference 19873 - spell_list
+-- Baron Rafe Dreuger 19874 - spell_list
+('1987301','19873','2','0','100','0','20','0','0','0','0','0','11','29390','0','0','0','0','0','0','0','0','0','0','Lord Crispin Ference - Cast Shield Wall at 20%'),
+-- Baroness Dorothea Millstipe 19875 - spell_lists
+('1987501','19875','27','0','100','1','29406','1','1500','8000','1','0','11','29406','0','0','0','0','0','0','0','0','0','0','Baroness Dorothea Millstipe - Cast Shadowform on Aura Missing'),
+-- Lord Robin Daris -- spell_list
 -- Conjured Water Elemental (21160) - npc_water_elemental
 -- Human Charger (21664) - npc_human_charger
 -- Human Cleric (21682) - npc_human_cleric

--- a/Updates/0070_kara_moroes_adds.sql
+++ b/Updates/0070_kara_moroes_adds.sql
@@ -29,7 +29,6 @@ INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, T
 ('1987401', '1', '29385', '0', '-1', '0', '0', '100', '0','5500','16000','16000','25000', 'Baron Rafe Dreuger - Seal of Command - on self'),
 ('1987401', '2', '29386', '0', '-1', '1', '0', '100', '0','14000','23000','19000','25000', 'Baron Rafe Dreuger - Judgement of Command - on Current');
 
-
 -- Lord Robin Daris 19876
 -- Harmstring on Current
 -- Mortal Strike on Current
@@ -63,7 +62,6 @@ INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, T
 ('1987301', '1', '29567', '0', '-1', '1', '0', '100', '0','8000','20000','14000','30000', 'Lord Crispin Ference - Heroic Strike - on Current'),
 ('1987301', '2', '11972', '0', '-1', '102', '0', '100', '0','8000','18000','12500','30000', 'Lord Crispin Ference - Shield Bash - on Casting');
 
-
 -- Lady Catriona Von'Indi 19872
 -- Power Word: Shield low CD on friendly missing buff including self 
 -- Greater Heal - missing 75% health 
@@ -82,7 +80,6 @@ INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, T
 ('1987201', '2', '15090', '0', '-1', '3', '0', '100', '0','8000','23000','8000','23000', 'Lady Catriona Von''Indi - Dispel Magic - Hardcoded - eligible friendly dispel'),
 ('1987201', '3', '15090', '0', '-1', '100', '0', '100', '0','8000','23000','8000','23000', 'Lady Catriona Von''Indi - Dispel Magic - on Random'),
 ('1987201', '4', '29563', '0', '-1', '1', '0', '100', '0','20000','30000','20000','30000', 'Lady Catriona Von''Indi - Holy Fire - on Current');
-
 
 -- Lady Keira Berrybuck 17007
 -- Casts Holy Light (small) 29562 when friendly or self missing 50%
@@ -104,6 +101,7 @@ INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, T
 ('1700701', '2', '29381', '0', '-1', '1', '0', '100', '0','1000','5000','30000','40000', 'Lady Keira Berrybuck - Greater Blessing of Might - on self');
 
 -- New creature_spell_target 
+DELETE FROM creature_spell_targeting WHERE Id IN (106, 107, 206, 207);
 INSERT INTO `creature_spell_targeting` (`Id`, `Type`, `Param1`, `Param2`, `Param3`, `UnitCondition`, `Comments`) VALUES 
 -- taken from cmangos-wotlk
 ('106', '1', '0', '1', '6', '-1', 'Attack - random player non tank mana user'),

--- a/Updates/0070_kara_moroes_adds.sql
+++ b/Updates/0070_kara_moroes_adds.sql
@@ -1,0 +1,113 @@
+-- Moroes Adds
+-- Baroness Dorothea Millstipe 19875
+-- Mana Burn on Random Mana User - high CD
+-- Mind Flay on Current
+UPDATE creature_template SET SpellList = 1987501 WHERE entry=19875;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1987501';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1987501, 'Karazhan - Baroness Dorothea Millstipe', 0, 0);
+
+DELETE FROM creature_spell_list WHERE Id = '1987501';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1987501', '0', '29405', '0', '-1', '107', '0', '100', '0','15000','30000','15000','30000', 'Baroness Dorothea Millstipe - Mana Burn - Random Mana User'),
+('1987501', '1', '29570', '0', '-1', '1', '0', '100', '0','6000','15000','6500','16500', 'Baroness Dorothea Millstipe - Mind Flay - on Current');
+
+-- Baron Rafe Dreuger 19874 
+-- Hammer of Justice 13005 on Tank
+-- Seal of Command 29385 on Self
+-- Judgement of Command 29386 - on Current
+UPDATE creature_template SET SpellList = 1987401 WHERE entry=19874;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1987401';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1987401, 'Karazhan - Baron Rafe Dreuger', 0, 0);
+
+DELETE FROM creature_spell_list WHERE Id = '1987401';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1987401', '0', '13005', '0', '-1', '1', '0', '100', '0','19000','33000','20000','35000', 'Baron Rafe Dreuger - Hammer of Justice - on Current'),
+('1987401', '1', '29385', '0', '-1', '0', '0', '100', '0','5500','16000','16000','25000', 'Baron Rafe Dreuger - Seal of Command - on self'),
+('1987401', '2', '29386', '0', '-1', '1', '0', '100', '0','14000','23000','19000','25000', 'Baron Rafe Dreuger - Judgement of Command - on Current');
+
+
+-- Lord Robin Daris 19876
+-- Harmstring on Current
+-- Mortal Strike on Current
+-- Whirlwind on Self
+UPDATE creature_template SET SpellList = 1987601 WHERE entry=19876;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1987601';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1987601, 'Karazhan - Lord Robin Daris', 0, 0);
+
+DELETE FROM creature_spell_list WHERE Id = '1987601';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1987601', '0', '9080', '0', '-1', '1', '0', '100', '0','6000','15000','12500','30000', 'Lord Robin Daris - Harmstring - on Current'),
+('1987601', '1', '29572', '0', '-1', '1', '0', '100', '0','14000','28000','19500','25000', 'Lord Robin Daris - Mortal Strike - on Current'),
+('1987601', '2', '29573', '0', '-1', '0', '0', '100', '0','16000','23000','17000','29000', 'Lord Robin Daris - Whirlwind - on self');
+
+-- Lord Crispin Ference 19873 
+-- Disarm on Current
+-- Heroic Strike on Current
+-- Shield Bash on Casting
+-- Shield Wall on Self unter 15% life
+UPDATE creature_template SET SpellList = 1987301 WHERE entry=19873;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1987301';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1987301, 'Karazhan - Lord Crispin Ference', 0, 0);
+
+DELETE FROM creature_spell_list WHERE Id = '1987301';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1987301', '0', '8379', '0', '-1', '1', '0', '100', '0','14500','25000','20000','30000', 'Lord Crispin Ference - Harmstring - on Current'),
+('1987301', '1', '29567', '0', '-1', '1', '0', '100', '0','8000','20000','14000','30000', 'Lord Crispin Ference - Heroic Strike - on Current'),
+('1987301', '2', '11972', '0', '-1', '102', '0', '100', '0','8000','18000','12500','30000', 'Lord Crispin Ference - Shield Bash - on Casting');
+
+
+-- Lady Catriona Von'Indi 19872
+-- Power Word: Shield low CD on friendly missing buff including self 
+-- Greater Heal - missing 75% health 
+-- Dispel magic - dispel friendly including self
+-- Holy Fire on Current Target
+UPDATE creature_template SET SpellList = 1987201 WHERE entry=19872;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1987201';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1987201, 'Karazhan - Lady Catriona Von''Indi', 0, 0);
+
+DELETE FROM creature_spell_list WHERE Id = '1987201';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1987201', '0', '29408', '0', '-1', '5', '0', '100', '0','15000','25000','15000','25000', 'Lady Catriona Von''Indi - Power Word: Shield - friendly missing buff include self'),
+('1987201', '1', '29564', '0', '-1', '206', '0', '100', '0','10000','30000','10000','30000', 'Lady Catriona Von''Indi - Greater Heal - missing 75% including self'),
+('1987201', '2', '15090', '0', '-1', '3', '0', '100', '0','8000','23000','8000','23000', 'Lady Catriona Von''Indi - Dispel Magic - Hardcoded - eligible friendly dispel'),
+('1987201', '3', '15090', '0', '-1', '100', '0', '100', '0','8000','23000','8000','23000', 'Lady Catriona Von''Indi - Dispel Magic - on Random'),
+('1987201', '4', '29563', '0', '-1', '1', '0', '100', '0','20000','30000','20000','30000', 'Lady Catriona Von''Indi - Holy Fire - on Current');
+
+
+-- Lady Keira Berrybuck 17007
+-- Casts Holy Light (small) 29562 when friendly or self missing 50%
+-- Casts Holy Light (big) 29383 when under 10% health on self only
+-- Casts Divine Shield under 10%
+-- Cleanses friendly units
+-- Blessing of Might timer based
+UPDATE creature_template SET SpellList = 1700701 WHERE entry=17007;
+
+DELETE FROM creature_spell_list_entry WHERE Id = '1700701';
+INSERT INTO creature_spell_list_entry(Id, Name, ChanceSupportAction, ChanceRangedAttack) VALUES
+(1700701, 'Karazhan - Lady Keira Berrybuck', 0, 0);
+
+
+DELETE FROM creature_spell_list WHERE Id = '1700701';
+INSERT INTO creature_spell_list(Id, Position, SpellId, Flags, CombatCondition, TargetId, ScriptId, Availability, Probability, InitialMin, InitialMax, RepeatMin, RepeatMax, Comments) VALUES
+('1700701', '0', '29562', '0', '-1', '201', '0', '100', '0','3000','10000','3000','10000', 'Lady Keira Berrybuck - Holy Light - on friendly missing 50% including self'),
+('1700701', '1', '29380', '0', '-1', '3', '0', '100', '0','6000','13000','5500','15000', 'Lady Keira Berrybuck - Cleanse - Hardcoded - eligible friendly dispel'),
+('1700701', '2', '29381', '0', '-1', '1', '0', '100', '0','1000','5000','30000','40000', 'Lady Keira Berrybuck - Greater Blessing of Might - on self');
+
+-- New creature_spell_target 
+INSERT INTO `creature_spell_targeting` (`Id`, `Type`, `Param1`, `Param2`, `Param3`, `UnitCondition`, `Comments`) VALUES 
+-- taken from cmangos-wotlk
+('106', '1', '0', '1', '6', '-1', 'Attack - random player non tank mana user'),
+-- new one - including tank 
+('107', '1', '0', '0', '6', '-1', 'Attack - random player mana user'),
+('206', '2', '75', '1', '1', '-1', 'Support - missing 75% including self'),
+('207', '2', '75', '1', '0', '-1', 'Support - missing 75% excluding self');


### PR DESCRIPTION
This took me some good time of research.

Here is what i found out from wotlk classic tests/videos and what is different to current implementation with cai.

Baroness Dorothea Millstipe 
- Shadowform only gets Casted inCombat and if not already active (using creature_event_ai - EVENT_T_MISSING_AURA for this but this needs the core change in this pr https://github.com/cmangos/mangos-tbc/pull/614
- Mana Burn seems to have a high CD (using sniffs/ccsdb as evidence for this) (casted on mana users)

Baron Rafe Dreuger
- There is another Seal of Command listed on wowhead/ccsdb not sure if this gets used or is just the proc (id 20424)

Lord Crispin Ference
- Shield Wall only got used when npc was below 20% (using creature_event_ai for this, not repeatable), this could be wrong/wotlk only
- Shield Bash only on Casting players

Lady Catriona Von'Indi
- Shadow Word: Shield can get casted when npc has full life, only checks if Shield is already up 
- Greater Heal casted when friendly or self is below 75% health
- Dispel Magic gets casted offensive on Player or Defensive on friendly unit (including self)

Lady Keira Berrybuck
- Holy Light (Small) gets casted if friendly or self is unter 50% health
- Cleanse on friendly or self dispel
- Blessing of Might gets casted on her self even if she still has the buff, first cast rly early in fight 2nd with higher cd.
- Divine Shield got casted when below 10% health
- Holy Light (Big) got casted after Divine Shield