### PR TITLE
BRD: Fix the faction of Ribbly and his cronies after engaging them.

### DIFF
--- a/Updates/Instances/230_blackrock_depths.sql
+++ b/Updates/Instances/230_blackrock_depths.sql
@@ -3124,10 +3124,10 @@ DELETE FROM `dbscripts_on_gossip` WHERE `id` IN (194502,197001,964801);
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES
 (194502, 1000, 9, @OGUID+112, 300, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'spawn Spectral Chalice'),
 
-(197001, 0, 22, 21, 0, 0, 10043, @CGUID+1109, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
-(197001, 0, 22, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly - update faction'),
-(197001, 0, 22, 21, 0, 0, 10043, @CGUID+1110, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
-(197001, 0, 22, 21, 0, 0, 10043, @CGUID+1111, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
+(197001, 0, 22, 736, 0, 0, 10043, @CGUID+1109, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
+(197001, 0, 22, 736, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly - update faction'),
+(197001, 0, 22, 736, 0, 0, 10043, @CGUID+1110, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
+(197001, 0, 22, 736, 0, 0, 10043, @CGUID+1111, 16, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly Crony - update faction'),
 (197001, 3000, 0, 0, 0, 0, 0, 0, 0, 4973, 0, 0, 0, 0, 0, 0, 0, ''),
 (197001, 5000, 26, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Ribbly  - attack player'),
 


### PR DESCRIPTION
When you start the fight with Ribbly Screwspigot (9543) and his cronies in BRD, they change faction to become hostile and then start to attack players.

But the faction they change to is currently wrong, and they turn hostile for other residents of the bar too, which naturally then start attacking Ribbly and his cronies en mass!

Note: the new faction is coming from version 3.0.3 build 9183 sniffs.
