### PR TITLE
Fix the gold requirements of the alliance Paladin charger quest chain.

### DIFF
--- a/Updates/0393_paladin_charger_quest_gold.sql
+++ b/Updates/0393_paladin_charger_quest_gold.sql
@@ -1,0 +1,6 @@
+
+-- Quest 'Emphasis on Sacrifice' requires 150g
+UPDATE `quest_template` SET RewOrReqMoney = -1500000 WHERE entry = 7637;
+
+-- Quest 'Manna-Enriched Horse Feed' requires 50g
+UPDATE `quest_template` SET RewOrReqMoney = -500000 WHERE entry = 7645;


### PR DESCRIPTION
While testing the alliance paladin charger quest chain, I noticed some of the quests that should bring a gold cost were essentially for free. This PR fixes those quests.