### PR TITLE
GitHub: Fix date output for release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_OUTPUT
 
       - name: Upload Snapshot
         uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
This PR fixes the empty date value for release builds. Issue was caused because of using bash syntax instead of powershell.