### PR TITLE
Fix chat type for Core Hound (11671) texts.

### DIFF
--- a/Updates/0707_core_hound_bct.sql
+++ b/Updates/0707_core_hound_bct.sql
@@ -1,0 +1,6 @@
+
+-- %s collapses and begins to smolder.
+UPDATE broadcast_text SET ChatTypeID = 2 WHERE Id = 7866;
+
+-- %s reignites from the heat of another Core Hound!
+UPDATE broadcast_text SET ChatTypeID = 2 WHERE Id = 7867;


### PR DESCRIPTION
I recently noticed that we don't seem to have the Core Hound's collapse/reignite mechanic implemented in Molten Core (see for example [here](https://warcraft.wiki.gg/wiki/Core_Hound_(Molten_Core))).

While testing my implementation, I noticed the relevant broadcast texts have the wrong type. They should be like an emote rather than a say, and this PR fixes that.