### PR TITLE
Fix imps being unable to autocast blood pact while in phase shift

### DIFF
--- a/Updates/0726_misc_fixes-4.sql
+++ b/Updates/0726_misc_fixes-4.sql
@@ -1,0 +1,8 @@
+# Enable Imp to autocast Blood Pact while in phase shift, since it can cast while it's in phase shift
+# not blizzlike, but skips having to change core for 1 edge case to fix the autocast
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '6307');
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '7804');
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '7805');
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '11766');
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '11767');
+UPDATE spell_template SET `AttributesEx6` = '8' WHERE (`Id` = '27268');


### PR DESCRIPTION
Imps can cast blood pact while in phase shift, but they are unable to autocast due to autocast checking immunity in the core. Since an imp will first phase shift before blood pact, it sees that it's immune. However it is possible to manually click on blood pact to cast it _while in phase shift_.

This probably needs an extensive look and cleanup. In the meantime, this allows imps to autocast blood pact when summoned if phase shift is also set to autocast.