### PR TITLE
Fix rogue d3 4set

### DIFF
--- a/Updates/0735_misc_fixes_1.sql
+++ b/Updates/0735_misc_fixes_1.sql
@@ -1,2 +1,2 @@
-# fix rogue d3 4 set having wrong flags
+-- fix rogue d3 4 set having wrong flags
 UPDATE `spell_affect` SET `SpellFamilyMask` = '34359869440' WHERE (`entry` = '37166') and (`effectId` = '0');

--- a/Updates/0735_misc_fixes_1.sql
+++ b/Updates/0735_misc_fixes_1.sql
@@ -1,0 +1,2 @@
+# fix rogue d3 4 set having wrong flags
+UPDATE `spell_affect` SET `SpellFamilyMask` = '34359869440' WHERE (`entry` = '37166') and (`effectId` = '0');


### PR DESCRIPTION
Fix wrong flags for Rogue D3 4 set bonus effect, should only be eviscerate + envenom (131072+34359738368)