### PR TITLE
Fix underbog Bog Giant and Underbog Lord wrong spells

### DIFF
--- a/Updates/0738_underbog_fixes.sql
+++ b/Updates/0738_underbog_fixes.sql
@@ -2,9 +2,3 @@
 -- Remove Trample (spell 2) from Heroic Bog Giant, move spell 3 to spell 2
 DELETE FROM `creature_spell_list` WHERE `Id` = 2016401 AND `Position` = 2;
 UPDATE `creature_spell_list` SET `Position` = 2 WHERE `Id` = 2016401 AND `Position` = 3;
-
--- Add Enrage at low hp (seems below 30) to Normal Bog Giant
-INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1772301', '3', '8599', '0', '5364', '0', '0', '100', '1', '0', '0', '0', '0', 'Bog Giant - Enrage below 30');
-
--- Add Enrage at low hp (seems below 15) to Normal Underbog Lord
-INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1773401', '3', '8599', '0', '1107', '0', '0', '100', '1', '0', '0', '0', '0', 'Underbog Lord - Enrage below 15');

--- a/Updates/0738_underbog_fixes.sql
+++ b/Updates/0738_underbog_fixes.sql
@@ -5,3 +5,6 @@ UPDATE `creature_spell_list` SET `Position` = 2 WHERE `Id` = 2016401 AND `Positi
 
 -- Add Enrage at low hp (seems below 30) to Normal Bog Giant
 INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1772301', '3', '8599', '0', '5364', '0', '0', '100', '1', '0', '0', '600000', '600000', 'Bog Giant - Enrage below 30');
+
+-- Add Enrage at low hp (seems below 15) to Normal Underbog Lord
+INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1773401', '3', '8599', '0', '1107', '0', '0', '100', '1', '0', '0', '600000', '600000', 'Underbog Lord - Enrage below 15');

--- a/Updates/0738_underbog_fixes.sql
+++ b/Updates/0738_underbog_fixes.sql
@@ -4,7 +4,7 @@ DELETE FROM `creature_spell_list` WHERE `Id` = 2016401 AND `Position` = 2;
 UPDATE `creature_spell_list` SET `Position` = 2 WHERE `Id` = 2016401 AND `Position` = 3;
 
 -- Add Enrage at low hp (seems below 30) to Normal Bog Giant
-INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1772301', '3', '8599', '0', '5364', '0', '0', '100', '1', '0', '0', '600000', '600000', 'Bog Giant - Enrage below 30');
+INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1772301', '3', '8599', '0', '5364', '0', '0', '100', '1', '0', '0', '0', '0', 'Bog Giant - Enrage below 30');
 
 -- Add Enrage at low hp (seems below 15) to Normal Underbog Lord
-INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1773401', '3', '8599', '0', '1107', '0', '0', '100', '1', '0', '0', '600000', '600000', 'Underbog Lord - Enrage below 15');
+INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1773401', '3', '8599', '0', '1107', '0', '0', '100', '1', '0', '0', '0', '0', 'Underbog Lord - Enrage below 15');

--- a/Updates/0738_underbog_fixes.sql
+++ b/Updates/0738_underbog_fixes.sql
@@ -1,0 +1,7 @@
+-- Underbog
+-- Remove Trample (spell 2) from Heroic Bog Giant, move spell 3 to spell 2
+DELETE FROM `creature_spell_list` WHERE `Id` = 2016401 AND `Position` = 2;
+UPDATE `creature_spell_list` SET `Position` = 2 WHERE `Id` = 2016401 AND `Position` = 3;
+
+-- Add Enrage at low hp (seems below 30) to Normal Bog Giant
+INSERT INTO `creature_spell_list` (`Id`, `Position`, `SpellId`, `Flags`, `CombatCondition`, `TargetId`, `ScriptId`, `Availability`, `Probability`, `InitialMin`, `InitialMax`, `RepeatMin`, `RepeatMax`, `Comments`) VALUES ('1772301', '3', '8599', '0', '5364', '0', '0', '100', '1', '0', '0', '600000', '600000', 'Bog Giant - Enrage below 30');


### PR DESCRIPTION
Remove Trample (spell 2) from Heroic Bog Giant, move spell 3 to spell 2 in its place.

Add Enrage spell at low hp (seems below 30) to Normal Bog Giant.

Proof:
Normal Underbog Bog Giant:
https://youtu.be/_LRpztnnao8?t=241

You can see that it does the trample, all of the melee are affected (they have like 3 red spikes above their head), the tank dodges the attack. There is a yellow glow on the floor that comes out from the mob, and the screen shakes to show the effect. There's also a sound effect that goes with it too. This is also how the spell is shown in cmangos.

You can also see that when it gets low hp (around 25 but it jumps quickly), it has an Enrage spell.

Heroic Underbog Bog Giant:
https://youtu.be/kvXZdn8ePTo?t=897

You can see that during the course of killing this mob, it never does this Trample spell (there is no screen shake, sound, or effect above head of characters to show the effect), nor damage dealt (it currently deals 5k+ damage aoe in Heroic and can scale quickly due to the Growth spell damage modifier, understandably this is probably why it is not present in Heroic).

You can also see that there is a difference in the spells listed on wowhead from normal to heroic:

https://www.wowhead.com/tbc/npc=17723/bog-giant#abilities;mode:normal
https://www.wowhead.com/tbc/npc=17723/bog-giant#abilities;mode:heroic

Underbog Lord also has this same enrage spell, but at a lower HP, in Normal Mode:

https://youtu.be/_LRpztnnao8?t=1893
https://www.wowhead.com/tbc/npc=17734/underbog-lord#abilities;mode:normal