### PR TITLE
Chess event fixes

### DIFF
--- a/Updates/0740_chess_targeting.sql
+++ b/Updates/0740_chess_targeting.sql
@@ -14,7 +14,15 @@ UPDATE `spell_script_target` SET `targetEntry` = '21682' WHERE (`entry` = '37775
 UPDATE `spell_script_target` SET `targetEntry` = '21683' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21750');
 UPDATE `spell_script_target` SET `targetEntry` = '21684' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21752');
 
-# Armor and agility multiplier should be 0 for chess pieces as they have no armor
+-- Fix missing script targets for 37824 Shadow Mend Action
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '17469', '0');
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21748', '0');
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21750', '0');
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21747', '0');
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21726', '0');
+INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21752', '0');
+
+-- Armor and agility multiplier should be 0 for chess pieces as they have no armor
 UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '17469');
 UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21748');
 UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21750');

--- a/Updates/0740_chess_targeting.sql
+++ b/Updates/0740_chess_targeting.sql
@@ -1,0 +1,30 @@
+-- Fix Orc Warlock Poison Cloud targeting Orc units instead of Human units in Karazhan Chess Event
+UPDATE `spell_script_target` SET `targetEntry` = '17211' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '17469');
+UPDATE `spell_script_target` SET `targetEntry` = '21160' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '21726');
+UPDATE `spell_script_target` SET `targetEntry` = '21664' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '21747');
+UPDATE `spell_script_target` SET `targetEntry` = '21682' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '21748');
+UPDATE `spell_script_target` SET `targetEntry` = '21683' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '21750');
+UPDATE `spell_script_target` SET `targetEntry` = '21684' WHERE (`entry` = '37469') and (`type` = '1') and (`targetEntry` = '21752');
+
+-- Fix Chess NPC action - Poison Cloud targeting Orc units instead of Human units in Karazhan Chess Event
+UPDATE `spell_script_target` SET `targetEntry` = '17211' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '17469');
+UPDATE `spell_script_target` SET `targetEntry` = '21160' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21726');
+UPDATE `spell_script_target` SET `targetEntry` = '21664' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21747');
+UPDATE `spell_script_target` SET `targetEntry` = '21682' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21748');
+UPDATE `spell_script_target` SET `targetEntry` = '21683' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21750');
+UPDATE `spell_script_target` SET `targetEntry` = '21684' WHERE (`entry` = '37775') and (`type` = '1') and (`targetEntry` = '21752');
+
+# Armor and agility multiplier should be 0 for chess pieces as they have no armor
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '17469');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21748');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21750');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21747');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21726');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21752');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '17211');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21664');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21683');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21682');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21160');
+UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21684');
+

--- a/Updates/0740_chess_targeting.sql
+++ b/Updates/0740_chess_targeting.sql
@@ -22,17 +22,3 @@ INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffec
 INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21726', '0');
 INSERT INTO `spell_script_target` (`entry`, `type`, `targetEntry`, `inverseEffectMask`) VALUES ('37824', '1', '21752', '0');
 
--- Armor and agility multiplier should be 0 for chess pieces as they have no armor
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '17469');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21748');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21750');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21747');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21726');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21752');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '17211');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21664');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21683');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21682');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21160');
-UPDATE `creature_template` SET `ArmorMultiplier` = '0', `AgilityMultiplier` = 0 WHERE (`Entry` = '21684');
-


### PR DESCRIPTION
Companion PR to https://github.com/cmangos/mangos-tbc/pull/848

Address orc chess spells targeting wrong units ~and address the chess units needing to have 0 armor (therefore 0 armor multiplier and 0 agility multiplier).~ Chess pieces confirmed to have armor by sniff so the problem of their spells being reduced by armor has to be handled elsewhere.